### PR TITLE
`Make test` Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,14 @@ docs: ## builds documentation in _build/html
 	fi
 
 test: ## Automatically runs unit tests
-	@if [ -z $(DOCKERFILE_EXISTS) ]; then\
+	@if [ -z $(DOCKERFILE_EXISTS) ] && [ "$(filter-out $@,$(MAKECMDGOALS))" = "docker" ]; then\
 	  docker build -f UnitTestingDockerfile -t sdp-library-testing .;\
+		docker run --rm -t -v $(shell pwd):/usr/src/sdp-testing -w /usr/src/sdp-testing sdp-library-testing mvn clean verify;\
+	elif [ ! -z $(DOCKERFILE_EXISTS) ] && [ "$(filter-out $@,$(MAKECMDGOALS))" = "docker" ]; then\
+	  docker run --rm -t -v $(shell pwd):/usr/src/sdp-testing -w /usr/src/sdp-testing sdp-library-testing mvn clean verify;\
+	else\
+	  mvn clean verify;\
 	fi
-	docker run --rm -t -v $(shell pwd):/usr/src/sdp-testing -w /usr/src/sdp-testing sdp-library-testing mvn clean verify
 
 #push:
 #	make image

--- a/UnitTestingDockerfile
+++ b/UnitTestingDockerfile
@@ -1,0 +1,7 @@
+FROM maven:3-jdk-8-slim
+
+COPY ./* /usr/src/sdp-libraries/
+
+WORKDIR /usr/src/sdp-libraries
+
+RUN mvn generate-sources && mvn generate-test-sources


### PR DESCRIPTION
Updated the makefile so someone can run `make test` to run the unit tests.

It's also possible to run `make test docker` to execute the unit tests w/ Docker to ensure a uniform execution environment. During the first run a new container image is built, and subsequent runs use that container image. This cuts back on the time spent downloading dependencies.