### PR TITLE
Unit test fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 /*
-    org.jenkins-ci.jpi allows plugin dependency resolution 
-    when specifying jenkins plugin dependencies 
+    org.jenkins-ci.jpi allows plugin dependency resolution
+    when specifying jenkins plugin dependencies
 */
 plugins{
   id 'org.jenkins-ci.jpi' version '0.29.0'
-  id 'groovy' 
+  id 'groovy'
 }
 
 repositories {
@@ -15,16 +15,16 @@ repositories {
 }
 
 /*
-    Jenkins-Spock requires that there be a target directory 
-    so it can find compiled test classes so realigning 
-    project build directory. 
+    Jenkins-Spock requires that there be a target directory
+    so it can find compiled test classes so realigning
+    project build directory.
 */
-project.buildDir = "target" 
+project.buildDir = "target"
 sourceSets{
     main{
         groovy{
             /*
-                source directory for tests is each library directory 
+                source directory for tests is each library directory
                 besides their unit-tests
             */
             srcDirs = getLibraries()
@@ -46,16 +46,17 @@ sourceSets{
         }
         /*
             need to be able to access actual steps as test resources
-            but dont want to copy in $buildDir directory. 
+            but dont want to copy in $buildDir directory.
         */
         resources{
-            srcDirs = getLibraries()
+            srcDirs = [ "." ]
+            filter.setIncludes(getLibraries().collect{ it + "/**"})
         }
     }
 }
 
 /*
-    Find all of the library directories that have unit tests to execute. 
+    Find all of the library directories that have unit tests to execute.
 */
 ArrayList getLibraries(){
     File workspace = new File(".")
@@ -63,7 +64,7 @@ ArrayList getLibraries(){
 
     def libraries = collection.findAll{
         it.listFiles().find{ it.name.equals("unit-tests") }
-    }.collect{ it.getName() } 
+    }.collect{ it.getName() }
 
     return libraries
 }
@@ -86,8 +87,8 @@ dependencies {
     testCompile group: 'org.jenkins-ci', name: 'symbol-annotation', version:'1.10'
     compile group: 'org.codehaus.groovy', name: 'groovy-all', version:'2.4.11'
     testCompile group: 'org.spockframework', name: 'spock-core', version:'1.1-groovy-2.4'
-    
-    // our plugin deps 
+
+    // our plugin deps
     jenkinsTest group: 'org.jenkins-ci.plugins.workflow', name: 'workflow-step-api', version:'2.10'
     jenkinsTest group: 'org.jenkins-ci.plugins.workflow', name: 'workflow-cps', version:'2.36'
     jenkinsTest group: 'org.jenkins-ci.plugins.workflow', name: 'workflow-scm-step', version:'2.7'

--- a/unit_test.Dockerfile
+++ b/unit_test.Dockerfile
@@ -1,7 +1,6 @@
 FROM gradle:4.10.2-jdk8
 
-USER root 
+USER root
 COPY build.gradle /app/build.gradle
-WORKDIR /app 
-RUN gradle downloadDependencies
-
+WORKDIR /app
+#RUN gradle downloadDependencies

--- a/unit_test.Dockerfile
+++ b/unit_test.Dockerfile
@@ -3,4 +3,3 @@ FROM gradle:4.10.2-jdk8
 USER root
 COPY build.gradle /app/build.gradle
 WORKDIR /app
-#RUN gradle downloadDependencies


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Two changes in this PR:

1. unit_test.Dockerfile no longer runs the downloadDependencies Gradle task. It seems that that task was removed from build.gradle, and the tests run fast enough that downloading the dependencies ahead of time is no longer as useful.

2. When running the "test" Gradle task, the resources are properly named. Before, the contents of the library folders, as opposed to the folders themselves were being copied into the test resources directory. This presents two problems: the unit tests expect a step's groovy file to be inside a library folder, and libraries that provide identically-named steps would cause collisions. Now, the entire library folder is copied into the test resources directory.

## How Has This Been Tested

1) Dockerfile update
  a) removed the existing sdp-library-testing image from my laptop
  b) successfully ran `make test docker`, which builds the sdp-library-testing container image if it does not exist
  c) successfully re-ran `make test docker`

2) Fix to test resources
  a) removed the `target` directory, which contains the test resources directory, `test-classes`
  b) successfully ran `make test`
  c) checked `target/test-classes` to confirm it contained the expected files/folders
  d) successfully re-ran `make test`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have updated the Change Log appropriately. 