### PR TITLE
Allow for optional image promotion on deploy_to after a merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ sourceSets{
             moving the compiled test classes so that Jenkins-Spock
             can find them.
         */
-        output.resourcesDir("target/test-classes")
+        output.resourcesDir("${buildDir}/test-classes")
         groovy{
             /*
                 The location of the unit tests are the "unit-tests"
@@ -44,8 +44,12 @@ sourceSets{
             */
             srcDirs = getLibraries().collect{ "${it}/unit-tests" }
         }
+        /*
+            need to be able to access actual steps as test resources
+            but dont want to copy in $buildDir directory. 
+        */
         resources{
-            srcDirs = [ "." ]
+            srcDirs = getLibraries()
         }
     }
 }

--- a/openshift/README.rst
+++ b/openshift/README.rst
@@ -1,35 +1,35 @@
-.. _OpenShift Library: 
+.. _OpenShift Library:
 ---------
 OpenShift
 ---------
 
-OpenShift is an enterprise grade distribution of Kubernetes built by Red Hat. For information on 
-deploying OpenShift inside Booz Allen's CSN AWS environment, refer to our 
+OpenShift is an enterprise grade distribution of Kubernetes built by Red Hat. For information on
+deploying OpenShift inside Booz Allen's CSN AWS environment, refer to our
 :ref:`guide <deploy openshift on aws csn>`
 
-This library allows you to perform deployments to static or ephemeral application environments with  
-Helm_ 
+This library allows you to perform deployments to static or ephemeral application environments with
+Helm_
 
 
 Steps Provided
 ##############
 
 * deploy_to
-* ephemeral 
+* ephemeral
 
 Library Configurations
 ######################
 
-The configurations for the OpenShift library can be specified at multiple levels. Given this 
+The configurations for the OpenShift library can be specified at multiple levels. Given this
 additional configurability the typical table of configuration options would be less clear than
-examples, so we'll be breaking it down per configuration portion. 
+examples, so we'll be breaking it down per configuration portion.
 
 OpenShift URL
 *************
 The OpenShift URL can be defined in the library spec or on a per application environment basis.
 
 For example, it's common to have a cluster for lower environments with a separate cluster for
-production.  You would specify this as follows: 
+production.  You would specify this as follows:
 
 .. code:: groovy
 
@@ -44,93 +44,93 @@ production.  You would specify this as follows:
       }
       prod{
         short_name = "prod"
-        long_name = "Production" 
-        openshift_url = "https://openshift.prod.example.com:8443" 
+        long_name = "Production"
+        openshift_url = "https://openshift.prod.example.com:8443"
       }
     }
     libraries{
       openshift{
-        url = "https://openshift.dev.example.com:8443" 
+        url = "https://openshift.dev.example.com:8443"
       }
     }
 
 With this configuration, ``https://openshift.dev.example.com:8443`` would be used when deploying
-to ``dev`` and ``test`` while ``https://openshift.prod.example.com:8443`` would be used when 
-deploying to ``prod`` 
+to ``dev`` and ``test`` while ``https://openshift.prod.example.com:8443`` would be used when
+deploying to ``prod``
 
 Helm Configuration
 ******************
 
 We use Helm_ for a deployment mechanism to OpenShift.  Helm is a package manager and templating
-engine for Kubernetes manifests.  Using Helm, the typical YAML manifests used to deploy to 
+engine for Kubernetes manifests.  Using Helm, the typical YAML manifests used to deploy to
 Kubernetes distributions can be templatized for reuse.  In our case, a different values file is
-used for each static application environment. 
+used for each static application environment.
 
-**Deploy the Tiller Server** 
+**Deploy the Tiller Server**
 
-You can configure Helm for multitenancy by using our 
-:ref:`environment provisioning script <helm environment provisioning script>`. 
+You can configure Helm for multitenancy by using our
+:ref:`environment provisioning script <helm environment provisioning script>`.
 
 Instead of using Helm as a package manager by bundling the charts and deploying them to a chart
 repository, we instead use a configuration repository as our infrastructure as code mechanism.
 
-**Create Helm Configuration Repository** 
+**Create Helm Configuration Repository**
 
 You'll need to create a GitHub repository to store the helm chart for your application(s). See the
-`helm docs on provisioning a new chart`_ to get intialize the repository with the skeleton for your chart. 
+`helm docs on provisioning a new chart`_ to get intialize the repository with the skeleton for your chart.
 
 How you choose to build your helm chart is up to you, you can put every api object in the ``templates``
 directory or have subcharts for each individual microservice.  SDP doesn't care, as all it does is clone
-the github repository and deploy the chart using the specified values file. 
+the github repository and deploy the chart using the specified values file.
 
-**Values File Conventions** 
+**Values File Conventions**
 
 Given that we tag container images using the git SHA, SDP will clone your helm configuration repository and
-update a key corresponding to the current version of each container image for each application environment. 
+update a key corresponding to the current version of each container image for each application environment.
 
 As such, a certain syntax is required in your values file.  You must have an ``image_shas`` key. SDP will
 automatically add subkeys for each repositories under this ``image_shas`` with a value that is the git SHA.
 
 `Given that YAML keys can't have hypens, hyphens in repository names will be replaced with underscores.`
 
-.. code:: yaml 
+.. code:: yaml
 
-    image_shas: 
+    image_shas:
       my_sample_application: abcdefgh
       another_repo: abcdef
-  
-you can add whatever other keys are necessary to appropriately parameterize your helm chart. 
 
-**Helm Configurations for the Library** 
+you can add whatever other keys are necessary to appropriately parameterize your helm chart.
+
+**Helm Configurations for the Library**
 
 The helm configuration repository, github credential, tiller namespace, and tiller credential  can be configured
-globally in the library spec and overriden for specific application environments. 
+globally in the library spec and overriden for specific application environments.
 
-The values file to will default to ``values.${app_env.short_name}.yaml``, or can be overridden via ``app_env.chart_values_file``. 
+The values file to will default to ``values.${app_env.short_name}.yaml``, or can be overridden via ``app_env.chart_values_file``.
 
 The name of the release will default to ``app_env.short_name``, or can be overridden via ``app_env.tiller_release_name``
 
-An example of helm configurations: 
+An example of helm configurations:
 
 .. code:: groovy
 
     application_environments{
       dev{
         short_name = "dev"
-        long_name = "Development" 
-        chart_values_file = "dev_values.yaml" 
+        long_name = "Development"
+        chart_values_file = "dev_values.yaml"
       }
       test{
-        short_name = "test" 
-        long_name = "Test" 
-        tiller_release_name = "banana" 
+        short_name = "test"
+        long_name = "Test"
+        tiller_release_name = "banana"
 
       }
       prod{
         short_name = "prod"
-        long_name = "Production" 
-        tiller_namespace = "rhs-tiller-prod" 
-        tiller_credential = "rhs-tiller-prod" 
+        long_name = "Production"
+        tiller_namespace = "rhs-tiller-prod"
+        tiller_credential = "rhs-tiller-prod"
       }
     }
     libraries{
@@ -139,6 +139,52 @@ An example of helm configurations:
         helm_configuration_repository_credential = "github"
         tiller_namespace = "rhs-tiller"
         tiller_credential = "rhs-tiller"
+      }
+    }
+
+Promoting Images
+****************
+
+It's often beneficial to build a container image once, and then promote that image
+through different application environments. This makes it possible to test the
+content of an image once in a lower environment, and remain confident that the
+results of those tests would be the same as an image is promoted. Promoting
+images also speeds up the CI/CD pipeline, as building a container image is often
+the most time-consuming part of the pipeline.
+
+By default, the ``deploy_to()`` step of the Openshift pipeline library will
+promote a container image if it can expect one to exist, which is when the most
+recent code change was a **merge** into the given code branch. The image would
+be expected to be built from an earlier commit, or while there was an open PR.
+
+You can override this default for the entire pipeline by setting the
+``promote_previous_image`` config setting to **false**. You can also choose
+whether or not to promote images for each application environment individually
+through the ``promote_previous_image`` application_environment setting. This
+app_env setting takes priority over the config setting.
+
+An example of these settings' usage:
+
+.. code:: groovy
+
+    application_environments{
+      dev{
+        short_name = "dev"
+        long_name = "Development"
+        promote_previous_image = false
+      }
+      prod{
+        short_name = "prod"
+        long_name = "Production"
+      }
+    }
+    libraries{
+      openshift{
+        helm_configuration_repository = "https://github.boozallencsn.com/Red-Hat-Summit/helm-configuration.git"
+        helm_configuration_repository_credential = "github"
+        tiller_namespace = "rhs-tiller"
+        tiller_credential = "rhs-tiller"
+        promote_previous_image = true //note: making this setting true is redundant, since true is the default
       }
     }
 
@@ -149,14 +195,15 @@ Putting It All Together
 .. csv-table:: OpenShift Library Configuration Options
    :header: "Field", "Description", "Default Value", "Defined On"
 
-   "openshift_url", "The OpenShift Console URL when specified per app env", , "app_env" 
-   "url", "The OpenShift Console URL when specified globally", , "library spec" 
+   "openshift_url", "The OpenShift Console URL when specified per app env", , "app_env"
+   "url", "The OpenShift Console URL when specified globally", , "library spec"
    "helm_configuration_repository", "The GitHub Repository containing the helm chart(s) for this application", ,"both"
    "helm_configuration_repository_credential", "The Jenkins credential ID to access the helm configuration GitHub repository", , "both"
    "tiller_namespace", "The tiller namespace for this application", , "both"
    "tiller_credential", "The Jenkins credential ID referencing an OpenShift credential", , "both"
-   "tiller_release_name", "The name of the release to deploy", , "app env"   
-   "chart_values_file", "The values file to use for the release", , "app_env" 
+   "tiller_release_name", "The name of the release to deploy", , "app env"
+   "chart_values_file", "The values file to use for the release", , "app_env"
+   "promote_previous_image", "Whether or not to promote a previously-built image", "(Boolean) true", "both"
 
 
 .. code:: groovy
@@ -164,30 +211,32 @@ Putting It All Together
     application_environments{
       dev{
         short_name = "dev"
-        long_name = "Development" 
-        chart_values_file = "dev_values.yaml" 
+        long_name = "Development"
+        chart_values_file = "dev_values.yaml"
       }
       test{
-        short_name = "test" 
-        long_name = "Test" 
-        tiller_release_name = "banana" 
+        short_name = "test"
+        long_name = "Test"
+        tiller_release_name = "banana"
 
       }
       prod{
         short_name = "prod"
-        long_name = "Production" 
-        tiller_namespace = "rhs-tiller-prod" 
-        tiller_credential = "rhs-tiller-prod" 
-        openshift_url = "https://openshift.prod.example.com:8443" 
+        long_name = "Production"
+        tiller_namespace = "rhs-tiller-prod"
+        tiller_credential = "rhs-tiller-prod"
+        openshift_url = "https://openshift.prod.example.com:8443"
+        promote_previous_image = true
       }
     }
     libraries{
       openshift{
-        url = "https://openshift.dev.example.com:8443" 
+        url = "https://openshift.dev.example.com:8443"
         helm_configuration_repository = "https://github.boozallencsn.com/Red-Hat-Summit/helm-configuration.git"
         helm_configuration_repository_credential = "github"
         tiller_namespace = "rhs-tiller"
         tiller_credential = "rhs-tiller"
+        promote_previous_image = false
       }
     }
 
@@ -196,9 +245,9 @@ External Dependencies
 
 * Openshift is deployed and accessible from Jenkins
 * Helm configuration repository creates
-* Values files contain the ``image_shas`` key convention 
+* Values files contain the ``image_shas`` key convention
 * A Jenkins credential exists to access helm configuration repository
-* A Jenkins credential exists to login with OpenShift CLI 
+* A Jenkins credential exists to login with OpenShift CLI
 
 
 .. _Helm: https://helm.sh/

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -91,6 +91,11 @@ void call(app_env){
       echo "expecting image was already built"
     }
     */
+    if (app_env.short_name == "prod"){
+      if (env.FEATURE_SHA){
+        retag(env.FEATURE_SHA, env.GIT_SHA) 
+      }
+    }
 
 
     withGit url: config_repo, cred: git_cred, {

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -75,7 +75,13 @@ void call(app_env){
         NOTE: this puts a dependency on the docker library (or whatever image building library
         is used.  this library must supply a retag method)
     */
-    if (env.FEATURE_SHA) retag(env.FEATURE_SHA, env.GIT_SHA)
+    def promote_image = app_env.promote_previous_image ?:
+                        config.promote_previous_image ?:
+                        "yes"
+
+    if (promote_image =~ /^[Yy]es/) {if (env.FEATURE_SHA) retag(env.FEATURE_SHA, env.GIT_SHA)}
+    else if (promote_image =~ /^[Nn]o$/) echo "expecting image was already built"
+    else error("Please set promote_previous_image in the Openshift library config to \"yes\" or \"no\"")
 
     withGit url: config_repo, cred: git_cred, {
       inside_sdp_image "openshift_helm", {

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -77,10 +77,10 @@ void call(app_env){
     */
     def promote_image = app_env.promote_previous_image ?:
                         config.promote_previous_image ?:
-                        "yes"
+                        true
 
-    if (promote_image =~ /^[Yy]es/) {if (env.FEATURE_SHA) retag(env.FEATURE_SHA, env.GIT_SHA)}
-    else if (promote_image =~ /^[Nn]o$/) echo "expecting image was already built"
+    if (promote_image) {if (env.FEATURE_SHA) retag(env.FEATURE_SHA, env.GIT_SHA)}
+    else if (!promote_image) echo "expecting image was already built"
     else error("Please set promote_previous_image in the Openshift library config to \"yes\" or \"no\"")
 
     withGit url: config_repo, cred: git_cred, {

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -75,10 +75,9 @@ void call(app_env){
         NOTE: this puts a dependency on the docker library (or whatever image building library
         is used.  this library must supply a retag method)
     */
-    /*
-    println "checking if we should promote the image"
-    def promote_image = app_env.promote_previous_image ?: config.promote_previous_image ?: false
-    
+    def promote_image = app_env.promote_previous_image != null ? app_env.promote_previous_image :
+                        config.promote_previous_image != null ? config.promote_previous_image :
+                        true
     if (!(promote_image instanceof Boolean)){
       error "OpenShift Library expects 'promote_previous_image' configuration to be true or false."
     }
@@ -89,12 +88,6 @@ void call(app_env){
       }
     } else{
       echo "expecting image was already built"
-    }
-    */
-    if (app_env.short_name == "prod"){
-      if (env.FEATURE_SHA){
-        retag(env.FEATURE_SHA, env.GIT_SHA) 
-      }
     }
 
 

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -75,8 +75,8 @@ void call(app_env){
         NOTE: this puts a dependency on the docker library (or whatever image building library
         is used.  this library must supply a retag method)
     */
-    def promote_image = app_env.promote_previous_image ?:
-                        config.promote_previous_image ?:
+    def promote_image = app_env.promote_previous_image != null ? app_env.promote_previous_image :
+                        config.promote_previous_image != null ? config.promote_previous_image :
                         true
     if (!(promote_image instanceof Boolean)){
       error "OpenShift Library expects 'promote_previous_image' configuration to be true or false."

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -75,10 +75,10 @@ void call(app_env){
         NOTE: this puts a dependency on the docker library (or whatever image building library
         is used.  this library must supply a retag method)
     */
+    /*
     println "checking if we should promote the image"
-    def promote_image = app_env.promote_previous_image != null ? app_env.promote_previous_image :
-                        config.promote_previous_image != null ? config.promote_previous_image :
-                        true
+    def promote_image = app_env.promote_previous_image ?: config.promote_previous_image ?: false
+    
     if (!(promote_image instanceof Boolean)){
       error "OpenShift Library expects 'promote_previous_image' configuration to be true or false."
     }
@@ -90,6 +90,7 @@ void call(app_env){
     } else{
       echo "expecting image was already built"
     }
+    */
 
 
     withGit url: config_repo, cred: git_cred, {

--- a/openshift/deploy_to.groovy
+++ b/openshift/deploy_to.groovy
@@ -75,6 +75,7 @@ void call(app_env){
         NOTE: this puts a dependency on the docker library (or whatever image building library
         is used.  this library must supply a retag method)
     */
+    println "checking if we should promote the image"
     def promote_image = app_env.promote_previous_image != null ? app_env.promote_previous_image :
                         config.promote_previous_image != null ? config.promote_previous_image :
                         true

--- a/openshift/unit-tests/DeployToSpec.groovy
+++ b/openshift/unit-tests/DeployToSpec.groovy
@@ -297,6 +297,33 @@ public class DeployToSpec extends JenkinsPipelineSpecification {
       1 * getPipelineMock("sh")( "rm special_values_file.yaml" )
   }
 
+  def "by default, promote the previously built image if one is expected to exist" () {
+    // setup:
+    //   deff app_env = [short_name: 'env', long_name: 'Enviornment']
+  }
+
+  def "Use config.promote_image, if available, to determine whether or not to promote a previous image" () {
+
+  }
+
+  def "Use app_env.promote_image, if available, to determine whether or not to promote a previous image" () {
+
+  }
+
+  def "Retag the previously built image for promotion if we choose to && if one is expected to exist" () {
+
+  }
+
+  def "Don't retag the previous image if we choose not to" () {
+
+  }
+
+  def "Don't retag the previous image if there is no Feature SHA" () {
+    // and we can't expect such a corresponding image to exist
+
+  }
+
+
   /**************************
    update_values_file() tests
   ***************************/

--- a/openshift/unit-tests/DeployToSpec.groovy
+++ b/openshift/unit-tests/DeployToSpec.groovy
@@ -371,7 +371,9 @@ public class DeployToSpec extends JenkinsPipelineSpecification {
         app_env_val | config_val
         true        | true
         true        | false
+        true        | null
         null        | true
+        null        | null
   }
 
   def "Don't retag the previous image if we choose not to, even if there is a feature SHA" () {
@@ -389,6 +391,7 @@ public class DeployToSpec extends JenkinsPipelineSpecification {
         app_env_val | config_val
         false       | false
         false       | true
+        false       | null
         null        | false
   }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Currently if the pipeline has detected and recorded a "FEATURE_SHA," i.e. the last code change was a "merge," then it will _always_ attempt to pull a previously-built image from a PR or previous commit and promote it. These changes allow users to make this promotion process optional for their entire pipeline, or select to not promote images for certain application environments. 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added jenkins-spock unit tests to DeployToSpec.groovy. The tests ran as expected

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have updated the Change Log appropriately. 