### PR TITLE
Sdp libconfig fix

### DIFF
--- a/sdp/library_config.groovy
+++ b/sdp/library_config.groovy
@@ -1,7 +1,7 @@
 fields{
   required{
     images{
-      registry = ~/^http(s):\/\/[a-zA-Z0-9\-_\.]+(:\d+)?$/
+      registry = ~/^http(s)?:\/\/[a-zA-Z0-9\-_\.]+(:\d+)?$/
       cred = ~/^[a-zA-Z0-9\-_\.]+$/
     }
   }

--- a/sdp/library_config.groovy
+++ b/sdp/library_config.groovy
@@ -1,7 +1,7 @@
 fields{
   required{
     images{
-      registry = ~/^http[a-zA-Z0-9\-_\.]+(:\d+)?$/
+      registry = ~/^http(s):\/\/[a-zA-Z0-9\-_\.]+(:\d+)?$/
       cred = ~/^[a-zA-Z0-9\-_\.]+$/
     }
   }


### PR DESCRIPTION
# PR Details

Fixing a typo in the sdp library's library_config.groovy file, where one of the regex expressions was not formatted to match `http://` or `https://` at the beginning of the value.

## How Has This Been Tested

* Ran unit tests
* Tested regex expression w/ an [online checker](https://regexr.com/)
* Ran a simple pipeline using the updated library repo


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have updated the Change Log appropriately. 