### PR TITLE
Fix Docker Build for Repos with Uppercase Letters

### DIFF
--- a/docker/build.groovy
+++ b/docker/build.groovy
@@ -12,8 +12,8 @@ def call(){
 
       def images = get_images_to_build()
       images.each{ img ->
-        sh "docker build ${img.context} -t ${img.registry}/${img.repo}:${img.tag}"
-        sh "docker push ${img.registry}/${img.repo}:${img.tag}"
+        sh "docker build ${img.context} -t ${img.registry}/${img.repo.toLowerCase()}:${img.tag}"
+        sh "docker push ${img.registry}/${img.repo.toLowerCase()}:${img.tag}"
       }
 
     }

--- a/docker/build.groovy
+++ b/docker/build.groovy
@@ -12,8 +12,8 @@ def call(){
 
       def images = get_images_to_build()
       images.each{ img ->
-        sh "docker build ${img.context} -t ${img.registry}/${img.repo.toLowerCase()}:${img.tag}"
-        sh "docker push ${img.registry}/${img.repo.toLowerCase()}:${img.tag}"
+        sh "docker build ${img.context} -t ${img.registry}/${img.repo}:${img.tag}"
+        sh "docker push ${img.registry}/${img.repo}:${img.tag}"
       }
 
     }

--- a/docker/get_images_to_build.groovy
+++ b/docker/get_images_to_build.groovy
@@ -44,7 +44,7 @@ def call(){
       case null:
         images.push([
           registry: image_reg,
-          repo: "${path_prefix}${env.REPO_NAME}",
+          repo: "${path_prefix}${env.REPO_NAME}".toLowerCase(),
           tag: env.GIT_SHA,
           context: "."
         ])

--- a/docker/retag.groovy
+++ b/docker/retag.groovy
@@ -10,9 +10,9 @@ void call(old_tag, new_tag){
         login_to_registry()
 
         get_images_to_build().each{ img ->
-          sh "docker pull ${img.registry}/${img.repo}:${old_tag}"
-          sh "docker tag ${img.registry}/${img.repo}:${old_tag} ${img.registry}/${img.repo}:${new_tag}"
-          sh "docker push ${img.registry}/${img.repo}:${new_tag}"
+          sh "docker pull ${img.registry}/${img.repo.toLowerCase()}:${old_tag}"
+          sh "docker tag ${img.registry}/${img.repo.toLowerCase()}:${old_tag} ${img.registry}/${img.repo.toLowerCase()}:${new_tag}"
+          sh "docker push ${img.registry}/${img.repo.toLowerCase()}:${new_tag}"
         }
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes -->
Docker images cannot have uppercase letters in their names so if a repository has an uppercase letter, will receive the following error: flag: invalid reference format: repository name must be lowercase

## Description

<!--- Describe your changes in detail -->
Changed the build step so the repo name will always be lower case.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This branch was tested in an environment where we are building the docker image and deploying it. After making the change, we were able to deploy repositories that have uppercase letters in them. We did not see any other effects with this change.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I am submitting this pull request to the appropriate branch
- [ x] I have labeled this pull request appropriately
- [ x] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
