### PR TITLE
update enforce_quality_gate check to handle boolean false

### DIFF
--- a/sonarqube/static_code_analysis.groovy
+++ b/sonarqube/static_code_analysis.groovy
@@ -9,8 +9,8 @@ def call(){
   cred_id = config.credential_id ?:
             "sonarqube"
 
-  enforce = config.enforce_quality_gate ?:
-            true
+  enforce = config.containsKey("enforce_quality_gate") ? 
+            config.enforce_quality_gate : true
 
   stage("SonarQube Analysis"){
     inside_sdp_image "sonar-scanner", {


### PR DESCRIPTION
# PR Details

Bug fix to enable the enforce_quality_gate functionality of the SDP sonarqube library

## Description

The current check for `enforce_quality_gate` treats a value of `false` the same as if the parameter wasn't set at all. Since the default behavior is to set `enforce` to `true` (when `enforce_quality_gate` isn't set), there currently isn't a way to set `enforce` to `false`.

## How Has This Been Tested

1. Cloned the boozallen/sdp-libraries repo to local GitLab instance
2. Updated local copy of sdp-libraries/sonarqube/static_code_analysis.groovy with change committed here, as well as copious `println` statements to track variable values throughout stage
3. Pointed a Jenkins job to the local sdp-libraries repo and reran the static_code_analysis stage
4. Confirmed both `config.enforce_quality_gate` and `enforce` were set to false during pipeline
5. Confirmed SonarQube task completed with `Quality gate is 'ERROR'`
6. Confirmed that pipeline ended with `Finished: SUCCESS`
7. Reran steps 3-6 after updating our `pipeline_config.groovy` file to test once with `enforce_quality_gate` set to `true` and once without it set at all.
8. Confirmed `enforce` gets set to `true` in both cases, and the pipeline fails as the quality gate conditions are not met.

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
