### PR TITLE
add steps to SDP library to support JTE 1.7

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,6 +2,11 @@
 
 The Solution Delivery Platform's open source pipeline libraries plug in to the xref:jte:ROOT:index.adoc[Jenkins Templating Engine] to accelerate the development of a DevSecOps pipeline. 
 
+[IMPORTANT]
+====
+For any relevant upgrade notes about the SDP Pipeline Libraries, checkout the https://github.com/boozallen/sdp-libraries/releases[GitHub Releases]. 
+====
+
 == Motivation 
 
 The Jenkins pipeline-as-code that is developed to perform various tool integrations is largely undifferentiated.  That is to say, it doesn't really matter what project you're working on - the pipeline code that's written can be reused anywhere if the configuration is appropriately externalized.  

--- a/docs/modules/ROOT/pages/libraries/sdp.adoc
+++ b/docs/modules/ROOT/pages/libraries/sdp.adoc
@@ -13,6 +13,20 @@ The SDP library provides helper steps used by multiple libraries within sdp-libr
 
 |===
 
+.Lifecycle Hooks
+|===
+| Step | Hook | Purpose 
+
+| archive_pipeline_config()
+| `@Init`
+| Writes the aggregated pipeline configuration to a file and saves it as a build artifact
+
+| create_workspace_stash()
+| `@Validate`
+| If the pipeline job is a Multibranch Project, checkout the source code.  In either case, save a stash called "workspace" for other libraries to consume. 
+
+|===
+
 == Library Configuration Options
 
 .SDP Library Configuration Options

--- a/libraries/sdp/archive_pipeline_config.groovy
+++ b/libraries/sdp/archive_pipeline_config.groovy
@@ -1,0 +1,20 @@
+/*
+  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+
+import org.boozallen.plugins.jte.config.TemplateConfigObject
+import org.boozallen.plugins.jte.config.TemplateConfigDsl
+
+@Init
+void call(context){
+    TemplateConfigObject aggregated = new TemplateConfigObject(
+        config: pipelineConfig, // variable provided in binding by JTE
+        merge: [],
+        override: []
+    )
+    node{
+        writeFile text: TemplateConfigDsl.serialize(aggregated), file: "pipeline_config.groovy"
+        archiveArtifacts "pipeline_config.groovy"
+    }
+}

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -10,8 +10,9 @@ void call(context){
     node{
         cleanWs()
         try{
-            checkout scm
             throw new Exception("diff exception")
+            checkout scm
+            
         }catch(AbortException ex) {
             println "scm var not present, skipping source code checkout" 
         }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -11,6 +11,7 @@ void call(context){
         cleanWs()
         try{
             checkout scm
+            throw new Exception("diff exception")
         }catch(AbortException ex) {
             println "scm var not present, skipping source code checkout" 
         }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -24,5 +24,6 @@ void call(context){
 SCM getSCM(){
     GlobalVariable scmVar = GlobalVariable.byName("scm", currentBuild.rawBuild)
     SCM scm = scmVar.getValue(this)
+    println "scm = ${scm}"
     return scm
 }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -12,6 +12,7 @@ import org.boozallen.plugins.jte.console.TemplateLogger
 void call(context){
     node{
         def scm = getSCM()
+        println "scm = ${scm}"
         if(scm){
             cleanWs()
             checkout scm

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -13,7 +13,7 @@ void call(context){
     println "inside" 
     node{
         println "fetching scm" 
-        println "scm = ${getSCM()}"
+        println "scm = ${scm}"
         if(getSCM()){
             cleanWs()
             checkout getSCM()

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -3,13 +3,15 @@
   This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
 */
 
+import hudson.AbortException
+
 @Validate // validate so this runs prior to other @Init steps
 void call(context){
     node{
         cleanWs()
         try{
             checkout scm
-        }catch(any) {
+        }catch(AbortException ex) {
             println "scm var not present, skipping source code checkout" 
         }
         stash name: 'workspace', allowEmpty: true, useDefaultExcludes: false

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -1,0 +1,20 @@
+/*
+  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+import org.jenkinsci.plugins.workflow.cps.GlobalVariable
+import org.jenkinsci.plugins.workflow.multibranch.SCMVar
+
+@Validate // validate so this runs prior to other @Init steps
+void call(context){
+    GlobalVariable scm = GlobalVariable.byName("scm", currentBuild.rawBuild)
+    node{
+        if(scm instanceof SCMVar){
+            cleanWs()
+            checkout scm
+        } else {
+            println "scm var not present, skipping source code checkout" 
+        }
+        stash name: 'workspace', allowEmpty: true, useDefaultExcludes: false
+    }
+}

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -8,13 +8,9 @@ import hudson.scm.SCM
 
 @Validate // validate so this runs prior to other @Init steps
 void call(context){
-    println "inside "
-    GlobalVariable scmVar = GlobalVariable.byName("scm", currentBuild.rawBuild)
-    SCM scm = scmVar.getValue(this)
-    println scm
-
     node{
-        if(scm instanceof SCM){
+        def scm = getSCM()
+        if(scm){
             cleanWs()
             checkout scm
         } else {
@@ -22,4 +18,11 @@ void call(context){
         }
         stash name: 'workspace', allowEmpty: true, useDefaultExcludes: false
     }
+}
+
+@NonCPS
+SCM getSCM(){
+    GlobalVariable scmVar = GlobalVariable.byName("scm", currentBuild.rawBuild)
+    SCM scm = scmVar.getValue(this)
+    return scm
 }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -2,32 +2,16 @@
   Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
   This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
 */
-import org.jenkinsci.plugins.workflow.cps.GlobalVariable
-import org.jenkinsci.plugins.workflow.multibranch.SCMVar
-import hudson.scm.SCM
-import org.boozallen.plugins.jte.console.TemplateLogger
-
 
 @Validate // validate so this runs prior to other @Init steps
 void call(context){
-    println "inside" 
     node{
-        println "fetching scm" 
-        println "scm = ${scm}"
-        if(getSCM()){
-            cleanWs()
-            checkout getSCM()
-        } else {
+        cleanWs()
+        try{
+            checkout scm
+        }catch(any) {
             println "scm var not present, skipping source code checkout" 
         }
         stash name: 'workspace', allowEmpty: true, useDefaultExcludes: false
     }
-}
-
-@NonCPS
-SCM getSCM(){
-    GlobalVariable scmVar = GlobalVariable.byName("scm", currentBuild.rawBuild)
-    SCM scm = scmVar.getValue(this)
-    TemplateLogger.printWarning "scm = ${scm}"
-    return scm
 }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -5,6 +5,8 @@
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable
 import org.jenkinsci.plugins.workflow.multibranch.SCMVar
 import hudson.scm.SCM
+import org.boozallen.plugins.jte.console.TemplateLogger
+
 
 @Validate // validate so this runs prior to other @Init steps
 void call(context){
@@ -24,6 +26,6 @@ void call(context){
 SCM getSCM(){
     GlobalVariable scmVar = GlobalVariable.byName("scm", currentBuild.rawBuild)
     SCM scm = scmVar.getValue(this)
-    println "scm = ${scm}"
+    TemplateLogger.printWarning "scm = ${scm}"
     return scm
 }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -13,11 +13,10 @@ void call(context){
     println "inside" 
     node{
         println "fetching scm" 
-        def scm = getSCM()
-        println "scm = ${scm}"
-        if(scm){
+        println "scm = ${getSCM()}"
+        if(getSCM()){
             cleanWs()
-            checkout scm
+            checkout getSCM()
         } else {
             println "scm var not present, skipping source code checkout" 
         }

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -4,12 +4,17 @@
 */
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable
 import org.jenkinsci.plugins.workflow.multibranch.SCMVar
+import hudson.scm.SCM
 
 @Validate // validate so this runs prior to other @Init steps
 void call(context){
-    GlobalVariable scm = GlobalVariable.byName("scm", currentBuild.rawBuild)
+    println "inside "
+    GlobalVariable scmVar = GlobalVariable.byName("scm", currentBuild.rawBuild)
+    SCM scm = scmVar.getValue(this)
+    println scm
+
     node{
-        if(scm instanceof SCMVar){
+        if(scm instanceof SCM){
             cleanWs()
             checkout scm
         } else {

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -10,7 +10,9 @@ import org.boozallen.plugins.jte.console.TemplateLogger
 
 @Validate // validate so this runs prior to other @Init steps
 void call(context){
+    println "inside" 
     node{
+        println "fetching scm" 
         def scm = getSCM()
         println "scm = ${scm}"
         if(scm){

--- a/libraries/sdp/create_workspace_stash.groovy
+++ b/libraries/sdp/create_workspace_stash.groovy
@@ -10,9 +10,7 @@ void call(context){
     node{
         cleanWs()
         try{
-            throw new Exception("diff exception")
             checkout scm
-            
         }catch(AbortException ex) {
             println "scm var not present, skipping source code checkout" 
         }


### PR DESCRIPTION
# PR Details

Updates the `sdp` library so that the SDP Pipeline Libraries can support JTE 1.7. 

## Description

[JTE 1.7](https://github.com/jenkinsci/templating-engine-plugin/releases/tag/1.7) removed checking out a repository to create a "workspace" stash and archiving the aggregated pipeline configuration as a build artifact from its initialization process. 

This PR adds that functionality to the `sdp` library. 

## How Has This Been Tested

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
