### PR TITLE
remove Type Map from github init step context parameters

### DIFF
--- a/libraries/github/github_enterprise_constructor.groovy
+++ b/libraries/github/github_enterprise_constructor.groovy
@@ -4,7 +4,7 @@
 */
 
 @Init
-void call(Map context) {
+void call(context) {
   node{
       unstash "workspace"
 

--- a/libraries/github_enterprise/github_enterprise_constructor.groovy
+++ b/libraries/github_enterprise/github_enterprise_constructor.groovy
@@ -4,7 +4,7 @@
 */
 
 @Init
-void call(Map context) {
+void call(context) {
   node{
       unstash "workspace"
 

--- a/libraries/gitlab/gitlab_constructor.groovy
+++ b/libraries/gitlab/gitlab_constructor.groovy
@@ -4,7 +4,7 @@
 */
 
 @Init
-void call(Map context) {
+void call(context) {
   node{
       unstash "workspace"
 


### PR DESCRIPTION
# PR Details

JTE 1.7 changed the Lifecycle hook parameter type from a generic Map to a specific HookContext. 

Recommendation is to use Groovy Ducktyping and simply not specify the context param type. 

## Description

Removed Map type from context param

## How Has This Been Tested

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
