### PR TITLE
fix link to documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 This repository contains https://boozallen.com[Booz Allen's] pipeline libraries that integrate with the https://plugins.jenkins.io/templating-engine/[Jenkins Templating Engine].
 
-If you want to learn more, the best place to get started is the https://boozallen.github.io/sdp-docs/sdp-libraries/latest/index.html[documentation]. 
+If you want to learn more, the best place to get started is the https://boozallen.github.io/sdp-docs/sdp-libraries/[documentation]. 
 
 == Repository Structure
 


### PR DESCRIPTION
# PR Details

Updating readme link to documentation

## Description

Current link (https://boozallen.github.io/sdp-docs/sdp-libraries/latest/index.html) returns `Page Not Found`

## How Has This Been Tested

Tested current and updated link in Chrome and Safari.

## Types of Changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [ ] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
