### PR TITLE
Edit Lighthouse failure threshold docs for clarity.

### DIFF
--- a/docs/modules/ROOT/pages/libraries/google_lighthouse.adoc
+++ b/docs/modules/ROOT/pages/libraries/google_lighthouse.adoc
@@ -28,7 +28,7 @@ The great part about this library is that developers can also use Google Lightho
  
 | thresholds.performance.fail
 | Double
-| Performance scores less than this will fail the build 
+| Performance scores less than or equal to this will fail the build 
 | 49.0
 
 | thresholds.performance.warn
@@ -38,7 +38,7 @@ The great part about this library is that developers can also use Google Lightho
 
 | thresholds.accessibility.fail
 | Double
-| Accessibility scores less than this will fail the build 
+| Accessibility scores less than or equal to this will fail the build 
 | 49.0
 
 | thresholds.accessibility.warn
@@ -48,7 +48,7 @@ The great part about this library is that developers can also use Google Lightho
 
 | thresholds.best_practices.fail
 | Double
-| Best Practice scores less than this will fail the build 
+| Best Practice scores less than or equal to this will fail the build 
 | 49.0
 
 | thresholds.best_practices.warn
@@ -58,7 +58,7 @@ The great part about this library is that developers can also use Google Lightho
 
 | thresholds.search_engine_optimization.fail
 | Double
-| Search Engine Optimization scores less than this will fail the build 
+| Search Engine Optimization scores less than or equal to this will fail the build 
 | 49.0
 
 | thresholds.search_engine_optimization.warn


### PR DESCRIPTION
# PR Details

## Description

This PR edits the Lighthouse library documentation to make it clear that builds will fail if a score is less than or equal to the defined failure threshold. The existing documentation reads "less than this" but the [code for failure checking](https://github.com/boozallen/sdp-libraries/blob/master/libraries/google_lighthouse/accessibility_compliance_scan.groovy#L90) uses `<=` and not `<`.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I am submitting this pull request to the appropriate branch
- [X] I have labeled this pull request appropriately
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
