### PR TITLE
Allow Google Lighthouse Thresholds to be set to 0

### DIFF
--- a/libraries/google_lighthouse/accessibility_compliance_scan.groovy
+++ b/libraries/google_lighthouse/accessibility_compliance_scan.groovy
@@ -83,8 +83,16 @@ void validateResults(String resultsDir){
             title: "Search Engine Optimization"
         ]
     ].each{ category -> 
-        def failThreshold = config.thresholds?."${category.configKey}"?.fail ?: 49
-        def warnThreshold = config.thresholds?."${category.configKey}"?.warn ?: 89
+        def failThreshold = config.thresholds?."${category.configKey}"?.fail
+        if(!(failThreshold instanceof Number)){
+            failThreshold = 49
+        }
+
+        def warnThreshold = config.thresholds?."${category.configKey}"?.warn
+        if(!(warnThreshold instanceof Number)){
+            warnThreshold = 89
+        }
+        
         def score = results.categories[category.jsonKey]?.score * 100 
 
         if( score <= failThreshold ){


### PR DESCRIPTION
# PR Details

Edge case where if the fail or warn thresholds were set to 0, the default would be used.

This was caused by 0 evaluating to **false** in the elvis operator expression. 

## Description

<!--- Describe your changes in detail -->

## How Has This Been Tested

validated with mock inputs in the groovy console

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
