### PR TITLE
refactor sonarqube library

### DIFF
--- a/docs/modules/ROOT/pages/libraries/sonarqube.adoc
+++ b/docs/modules/ROOT/pages/libraries/sonarqube.adoc
@@ -21,9 +21,13 @@ Organizations can define Quality Profiles which are custom rule profiles that pr
 |===
 | Field | Description | Default Value
 
+| `installation_name`
+| The name of the SonarQube installation configured in `Manage Jenkins > Configure System`
+| "SonarQube"
+
 | `credential_id`
-| The Jenkins credential ID to use when authenticating to SonarQube.  Can either a valid username/password or an API Token stored in a Secret Text credential type. 
-| "sonarqube"
+| The Jenkins credential ID to use when authenticating to SonarQube.  Can either be a valid username/password or an API Token stored in a Secret Text credential type. 
+| If unset, the library will check if the installation defined via `installation_name` has a server authorization token configured.  If a server authorization token has been provided in the plugin configuration, then that will be the default.  If unset, then a credential id of "sonarqube" will be assumed.
 
 | `wait_for_quality_gate`
 | Whether or not to wait for SonarQube to send a webhook back to Jenkins notifying with the Quality Gate result
@@ -32,10 +36,6 @@ Organizations can define Quality Profiles which are custom rule profiles that pr
 | `enforce_quality_gate`
 | Determine whether the build will fail if the code does not pass the quality gate
 | true
-
-| `installation_name`
-| The name of the SonarQube installation configured in `Manage Jenkins > Configure System`
-| "SonarQube"
 
 | `stage_display_name`
 | Purely aesthetic.  The name of the stage block during analysis for pipeline visualization in the Jenkins console.
@@ -50,36 +50,75 @@ Organizations can define Quality Profiles which are custom rule profiles that pr
 | "HOURS" 
 
 | `cli_parameters`
-a| a list of additional CLI analysis parameters to pass the `sonar-scanner` cli.
+| a list of additional CLI analysis parameters to pass the `sonar-scanner` cli.
+| [ ]
 
-for example: 
+| `unstash`
+| a list of pre-existing stashes to try to unstash. Useful if a previous step creates compiled classes or test results for SonarQube to inspect. 
+| [ ] 
+
+|===
+
+== Analysis Parameters
+
+In SonarQube, https://docs.sonarqube.org/latest/analysis/analysis-parameters/[project analysis settings] can be provied to the SonarScanner cli in multiple ways. 
+
+The SonarScanner will look for the presence of a **sonar-project.properties** file in the current working directory. 
+
+Alternatively, users can use this library's `cli_parameters` configuration to pass an array of cli analysis parameters to SonarScanner.
+
+For example, 
 
 [source, groovy]
 ----
 libraries{
     sonarqube{
-        cli_parameters = [ "-Dsonar.java.binaries=empty" ]
+        cli_parameters = [ 
+            "-Dsonar.projectKey=myCoolProject",
+            "-Dsonar.projectName='My Cool Project'"
+        ]
     }
 }
 ----
 
-| []
+=== Environment Variables
 
-| `unstash`
-| a list of pre-existing stashes to try to unstash. Useful if a previous step creates compiled classes or test results for SonarQube to inspect. 
-| [] 
+It's possible to use pipeline environment variables to populate the analysis parameters.  This is especially useful when used with one of the source code management libraries to reference the branch name. 
 
-|===
+==== Configuration File 
 
-== Sonar Scanner Configurations
+.sonar-project.properties
+[source, txt]
+----
+sonar.projectName=My Cool Project: ${env.BRANCH_NAME}
+----
 
-Extra configuration options are available by leveraging SonarQube's https://docs.sonarqube.org/display/SONAR/Analysis+Parameters[sonar-project.properties] file. the sonar-project.properties file should be added to root of the source repositoy.
+==== CLI Parameters 
+
+.pipeline_config.groovy
+[source,groovy]
+----
+libraries{
+    sonarqube{
+        cli_parameters = [ 
+            "-Dsonar.projectName=\"My Cool Project: \$BRANCH_NAME\""
+        ]
+    }
+}
+----
 
 ==  External Dependencies
 
-* SonarQube must already be deployed. Reference the deployment script for SDP.
-* Jenkins must have a credential to access SonarQube, this is done by default when using the deployment script.
-* The SonarQube URL must be configured in `Manage Jenkins > Configure System`
+* A SonarQube server should be deployed
+* The https://plugins.jenkins.io/sonar/[SonarQube Scanner] plugin should be installed
+* The SonarQube Installation must be configured in `Manage Jenkins > Configure System > SonarQube servers`
+** The "Enable injection of SonarQube server configuration as build environment variables" checkbox should be checked
+
+== Authentication
+
+This library supports both username/password and API Token authentication to SonarQube. 
+
+If anonymous access is disabled for the SonarQube Server (*it probably should be*), then you will need to create an API Token and store it as a Secret Text credential in the Jenkins Credential Store for reference in `Manage Jenkins > Configure System > Sonarqube servers` as the `Server authentication token`.
 
 ==  Troubleshooting
 

--- a/docs/modules/ROOT/pages/libraries/sonarqube.adoc
+++ b/docs/modules/ROOT/pages/libraries/sonarqube.adoc
@@ -21,26 +21,55 @@ Organizations can define Quality Profiles which are custom rule profiles that pr
 |===
 | Field | Description | Default Value
 
-| credential_id
-| The Jenkins credential ID corresponding to a username/password credential to authenticate to the configured SonarQube server
+| `credential_id`
+| The Jenkins credential ID to use when authenticating to SonarQube.  Can either a valid username/password or an API Token stored in a Secret Text credential type. 
 | "sonarqube"
 
-| enforce_quality_gate
+| `wait_for_quality_gate`
+| Whether or not to wait for SonarQube to send a webhook back to Jenkins notifying with the Quality Gate result
+| true 
+
+| `enforce_quality_gate`
 | Determine whether the build will fail if the code does not pass the quality gate
 | true
 
-|===
+| `installation_name`
+| The name of the SonarQube installation configured in `Manage Jenkins > Configure System`
+| "SonarQube"
 
-== Example Configuration Snippet
+| `stage_display_name`
+| Purely aesthetic.  The name of the stage block during analysis for pipeline visualization in the Jenkins console.
+| "SonarQube Analysis"
 
-[source,groovy]
+| `timeout_duration`
+| The number representing how long to wait for the Quality Gate response before timing out
+| 1
+
+| `timeout_unit`
+| One of [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+| "HOURS" 
+
+| `cli_parameters`
+a| a list of additional CLI analysis parameters to pass the `sonar-scanner` cli.
+
+for example: 
+
+[source, groovy]
 ----
 libraries{
-  sonarqube{
-    credential_id = "sonarqube"
-  }
+    sonarqube{
+        cli_parameters = [ "-Dsonar.java.binaries=empty" ]
+    }
 }
 ----
+
+| []
+
+| `unstash`
+| a list of pre-existing stashes to try to unstash. Useful if a previous step creates compiled classes or test results for SonarQube to inspect. 
+| [] 
+
+|===
 
 == Sonar Scanner Configurations
 

--- a/libraries/sonarqube/library_config.groovy
+++ b/libraries/sonarqube/library_config.groovy
@@ -1,0 +1,14 @@
+fields{
+    required{}
+    optional{
+        wait_for_quality_gate = Boolean
+        enforce_quality_gate = Boolean
+        credential_id = String
+        installation_name = String
+        stage_display_name = String
+        timeout_duration = Number
+        timeout_unit = [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+        cli_parameters = List
+        unstash = List
+    }
+}

--- a/libraries/sonarqube/static_code_analysis.groovy
+++ b/libraries/sonarqube/static_code_analysis.groovy
@@ -77,12 +77,6 @@ def call(){
                     // build out the command to execute
                     ArrayList command = [ "sonar-scanner -X" ]
 
-                    projectKey = "$env.REPO_NAME:$env.BRANCH_NAME".replaceAll("/", "_")
-                    command << "-Dsonar.projectKey='${projectKey}'"
-                    
-                    projectName = "$env.REPO_NAME - $env.BRANCH_NAME"
-                    command << "-Dsonar.projectName='${projectName}'"
-
                     /*
                         if an API token was used, only provide -Dsonar.login 
                         if a username/password was used, provide both -Dsonar.login and -Dsonar.password
@@ -94,11 +88,6 @@ def call(){
                         command << "-Dsonar.login='${env.sq_user}' -Dsonar.password='${env.sq_token}'"
                     } else {
                         command << "-Dsonar.login='${env.sq_token}'"
-                    }
-
-                    command << "-Dsonar.projectBaseDir=."
-                    if (!fileExists("sonar-project.properties")){
-                        command << "-Dsonar.sources='./src'"
                     }
 
                     // join user provided params

--- a/libraries/sonarqube/static_code_analysis.groovy
+++ b/libraries/sonarqube/static_code_analysis.groovy
@@ -152,7 +152,7 @@ void validateInstallationExists(installation_name){
 */
 String fetchCredentialFromInstallation(installation_name){
     String id = SonarGlobalConfiguration.get().getInstallations().find{
-        it.getName() == sonarqube_installation
+        it.getName() == installation_name
     }.getCredentialsId()
     return id
 }

--- a/libraries/sonarqube/static_code_analysis.groovy
+++ b/libraries/sonarqube/static_code_analysis.groovy
@@ -131,7 +131,7 @@ def determineCredentialType(String cred_id){
 
     if(!(cred.getClass() in [UsernamePasswordCredentialsImpl, StringCredentialsImpl])){
         error """
-        SonarQube: Credential with id '${cred_id}'must be either: 
+        SonarQube: Credential with id '${cred_id}' must be either: 
           1. a valid username/password for SonarQube
           2. a secret text credential storing an API Token. 
         Found credential type: ${cred.getClass()}

--- a/libraries/sonarqube/static_code_analysis.groovy
+++ b/libraries/sonarqube/static_code_analysis.groovy
@@ -139,7 +139,7 @@ def determineCredentialType(String cred_id){
 
 void validateInstallationExists(installation_name){
     boolean exists = SonarGlobalConfiguration.get().getInstallations().find{
-        it.getName() == sonarqube_installation
+        it.getName() == installation_name
     } as boolean
     if(!exists){
         error "SonarQube: installation '${installation_name}' does not exist"

--- a/libraries/sonarqube/static_code_analysis.groovy
+++ b/libraries/sonarqube/static_code_analysis.groovy
@@ -3,39 +3,146 @@
   This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
 */
 
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.Credentials
+import com.cloudbees.plugins.credentials.CredentialsProvider
+import org.codehaus.groovy.runtime.NullObject
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
+
 def call(){
 
-  // sonarqube api token
-  cred_id = config.credential_id ?:
-            "sonarqube"
+    // default values for config options
+    LinkedHashMap defaults = [
+        credential_id: "sonarqube",
+        wait_for_quality_gate: true, 
+        enforce_quality_gate: true,
+        installation_name: "SonarQube",
+        timeout_duration: 1,
+        timeout_unit: "HOURS",
+        stage_display_name: "SonarQube Analysis",
+        unstash: [ "test-results" ],
+        cli_parameters: []
+    ]
 
-  enforce = config.containsKey("enforce_quality_gate") ? 
-            config.enforce_quality_gate : true
-
-  stage("SonarQube Analysis"){
-    inside_sdp_image "sonar-scanner", {
-      withCredentials([usernamePassword(credentialsId: cred_id, passwordVariable: 'token', usernameVariable: 'user')]) {
-        withSonarQubeEnv("SonarQube"){
-          unstash "workspace"
-          try{ unstash "test-results" }catch(ex){}
-          sh "mkdir -p empty"
-          projectKey = "$env.REPO_NAME:$env.BRANCH_NAME".replaceAll("/", "_")
-          projectName = "$env.REPO_NAME - $env.BRANCH_NAME"
-          def script = """sonar-scanner -X -Dsonar.login=${user} -Dsonar.password=${token} -Dsonar.projectKey="$projectKey" -Dsonar.projectName="$projectName" -Dsonar.projectBaseDir=. """
-           
-          if (!fileExists("sonar-project.properties"))
-            script += "-Dsonar.sources=\"./src\""
-
-          sh script
-            
-        }
-        timeout(time: 1, unit: 'HOURS') {
-          def qg = waitForQualityGate()
-          if (qg.status != 'OK' && enforce) {
-            error "Pipeline aborted due to quality gate failure: ${qg.status}"
-          }
-        }
-      }
+    // credential ID for SonarQube Auth
+    String cred_id = config.credential_id ?: defaults.credential_id
+    
+    // whether or not to wait for the quality gate 
+    Boolean wait = defaults.wait_for_quality_gate 
+    if(config.containsKey("wait_for_quality_gate")){
+        wait = config.wait_for_quality_gate
     }
-  }
+    // whether or not to enforce the SQ QG
+    Boolean enforce = defaults.enforce_quality_gate 
+    if(config.containsKey("enforce_quality_gate")){
+        enforce = config.enforce_quality_gate
+    }
+
+    // name of installation to use, as configured in Manage Jenkins > Configure System > SonarQube Installations
+    String installation_name = config.installation_name ?: defaults.installation_name
+
+    // purely aesthetic.  the name of the "Stage" for this task. 
+    String stage_display_name = config.stage_display_name ?: defaults.stage_display_name
+
+    // timeout settings
+    def timeout_duration = config.timeout_duration ?: defaults.timeout_duration
+    String timeout_unit = config.timeout_unit ?: defaults.timeout_unit
+
+    ArrayList unstashList = config.unstash ?: defaults.unstash
+
+    stage(stage_display_name){
+        inside_sdp_image "sonar-scanner", {
+            withCredentials(determineCredentialType(cred_id)) {
+                withSonarQubeEnv(installation_name){
+                    // fetch the source code 
+                    unstash "workspace"
+                    
+                    /*
+                      checks for the existence of a stash called "test-results"
+                      which may have been created by previous steps to store results
+                      that sonarqube will consume
+                    */
+                    unstashList.each{ ->
+                        try{ unstash it }catch(ex){}
+                    }
+                    
+                    /*
+                        creates an empty directory in the event that a value for 
+                        sonar.java.binaries needs to be provided when the binaries
+                        are not present during sonarqube analysis
+                    */
+                    sh "mkdir -p empty"
+                    
+                    // build out the command to execute
+                    ArrayList command = [ "sonar-scanner -X" ]
+
+                    projectKey = "$env.REPO_NAME:$env.BRANCH_NAME".replaceAll("/", "_")
+                    command << "-Dsonar.projectKey='${projectKey}'"
+                    
+                    projectName = "$env.REPO_NAME - $env.BRANCH_NAME"
+                    command << "-Dsonar.projectName='${projectName}'"
+
+                    /*
+                        if an API token was used, only provide -Dsonar.login 
+                        if a username/password was used, provide both -Dsonar.login and -Dsonar.password
+                        
+                        because of how determineCredentialType() works - the env var sq_user will 
+                        only be present if a username/password was provided.
+                    */
+                    if(env.sq_user){
+                        command << "-Dsonar.login='${env.sq_user}' -Dsonar.password='${env.sq_token}'"
+                    } else {
+                        command << "-Dsonar.login='${env.sq_token}'"
+                    }
+
+                    command << "-Dsonar.projectBaseDir=."
+                    if (!fileExists("sonar-project.properties")){
+                        command << "-Dsonar.sources='./src'"
+                    }
+
+                    // join user provided params
+                    command << (config.cli_parameters ?: defaults.cli_parameters)
+
+                    sh command.flatten().join(" ")
+
+                }
+                
+                if(wait){
+                    timeout(time: timeout_duration, unit: timeout_unit) {
+                        def qg = waitForQualityGate()
+                        if (qg.status != 'OK' && enforce) {
+                            error "Pipeline aborted due to quality gate failure: ${qg.status}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def determineCredentialType(String cred_id){
+    def allCreds = CredentialsProvider.lookupCredentials(Credentials, Jenkins.get(),null, null)
+    def cred = allCreds.find{ it.id.equals(cred_id) } 
+
+    if(cred == null){
+        error "SonarQube: Credential with id '${cred_id}' does not exist."
+    }
+
+    if(!(cred.getClass() in [UsernamePasswordCredentialsImpl, StringCredentialsImpl])){
+        error """
+        SonarQube: Credential with id '${cred_id}'must be either: 
+          1. a valid username/password for SonarQube
+          2. a secret text credential storing an API Token. 
+        Found credential type: ${cred.getClass()}
+        """.trim().stripIndent(8)
+    }
+
+    if(cred instanceof UsernamePasswordCredentialsImpl){
+        return [ [usernamePassword(credentialsId: cred_id, passwordVariable: 'sq_token', usernameVariable: 'sq_user')] ]
+    }
+
+    if(cred instanceof StringCredentialsImpl){
+        return [ string(credentialsId: cred_id, variable: 'sq_token') ] 
+    }
 }

--- a/libraries/sonarqube/static_code_analysis.groovy
+++ b/libraries/sonarqube/static_code_analysis.groovy
@@ -139,7 +139,7 @@ def determineCredentialType(String cred_id){
     }
 
     if(cred instanceof UsernamePasswordCredentialsImpl){
-        return [ [usernamePassword(credentialsId: cred_id, passwordVariable: 'sq_token', usernameVariable: 'sq_user')] ]
+        return [ usernamePassword(credentialsId: cred_id, passwordVariable: 'sq_token', usernameVariable: 'sq_user') ]
     }
 
     if(cred instanceof StringCredentialsImpl){


### PR DESCRIPTION
# PR Details

Refactoring of the SonarQube library to remove hard coded conventions and enhance configurability.

## Description 

### Breaking Changes

#### 1. `sonar.projectKey` & `sonar.projectName` 

Previously, the `sonarqube` library would hard code via cli parameters the values of `sonar.projectKey` and `sonar.projectName`.  The default values for these parameters required that a source code library was being used to populate `REPO_NAME` and `BRANCH_NAME` environment variables. 

These have been removed. 

You will need to set the value of `sonar.projectKey` and `sonar.projectName` via **either** a `sonar-project.properties` file at the root of the current working directory when `static_code_analysis()` is invoked: 

```
sonar.projectKey=myCoolProject:${env.BRANCH_NAME}
sonar.projectName=My Cool Project: ${env.BRANCH_NAME}
```

**or** by setting these values in `libraries.sonarqube.cli_parameters`: 

```
libraries{
    sonarqube{
        cli_parameters = [ 
            "-Dsonar.projectKey=\"myCoolProject:\$BRANCH_NAME\"",
            "-Dsonar.projectName=\"My Cool Project: \$BRANCH_NAME\""
        ]
    }
}
```

#### 2. `sonar.sources` 

Previously, if a `sonar-project.properties` file was not found, the library would hard code the value of `sonar.sources=./src` via a CLI parameter. 

This has been removed. 

You will need to set the value of `sonar.sources` via **either** a `sonar-project.properties` file **or** via the library's `libraries.sonarqube.cli_parameters` configuration option. 

#### 3. `sonar.projectBaseDir`

Previously, the library hard coded the value of `sonar.projectBaseDir` via a CLI analysis parameter. This was both unnecessary and prevented users from changing the analysis base directory. 

Users can now set the base directory for analysis by setting `sonar.projectBaseDir` in **either** a `sonar-project.properties` file **or** the library's `libraries.sonarqube.cli_parameters` array. 

### Enhancements

#### 1. SonarQube Installation Configurability

Previously, the library had an implicit requirement that the SonarQube server installation in `Manage Jenkins > Configure System > Sonarqube servers` be named `SonarQube`. 

This is now the default value of a library configuration named `installation_name`. 

#### 2. Authentication

Previously, the library required that a credential id be provided that referred to a username/password credential in the Jenkins credential store. 

The library has been upgraded to now support *either* a username/password credential id **or** a credential id that refers to a Secret Text credential type storing a SonarQube API Token. 

Furthermore, the library has been upgraded such that if `libraries.sonarqube.credential_id` **is not set** then the SonarQube Server Installation identified by `libraries.sonarqube.installation_name` will be checked to see if an "Authorization server token" has been configured. If an "Authorization server token" has been configured, then this same token will be used for authentication to the sonar-scanner cli. 

If the installation has not configured an "Authorization server token" **and** `libraries.sonarqube.credential_id` has not been set, then the default value will be "sonarqube". 

#### 3. Quality Gate Webhooks

Previously, the library required that a SonarQube webhook be configured to notify the pipeline as to the status of a project's Quality Gate after analysis. 

Users can now skip waiting for the Quality Gate results altogether by setting `libraries.sonarqube.wait_for_quality_gate=false`. 

Furthermore, the timeout duration to wait for the webhook notification can now be configured via `libraries.sonarqube.timeout_unit` and `libraries.sonarqube.timeout_duration` as opposed to previously having been hard coded to 1 hour. 

#### 4. CLI Parameters 

Previously, the only means of providing analysis paramters was via a `sonar-project.properties` file.  The library has been upgraded to allow cli parameters to be passed via the `library.sonarqube.cli_parameters` array. 

#### 5. Accessing compiled binaries and test artifacts

SonarQube can ingest compiled binaries and other test reports to aide in analysis. The library has been upgraded to accept an array of stash names to unstash if present by setting `libraries.sonarqube.unstash`. 

The default value is `libraries.sonarqube.unstash = [ "test-results" ]`. 

#### 6. Jenkins stage display name

To aide in pipeline visualization, the library wraps execution in a Jenkins "stage" called "SonarQube Analysis".  This is now the default value of the library configuration `libraries.sonarqube.stage_display_name`. 

## How Has This Been Tested

Tested extensively with a local Jenkins & SonarQube server. 

## Types of Changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
