### PR TITLE
with_secrets added, and document updated

### DIFF
--- a/docs/modules/ROOT/pages/libraries/sdp.adoc
+++ b/docs/modules/ROOT/pages/libraries/sdp.adoc
@@ -11,11 +11,14 @@ The SDP library provides helper steps used by multiple libraries within sdp-libr
 | ``inside_sdp_images(String image, Closure body)``
 | helper function that wraps ``docker.image(<image>).inside{}`` to execute a portion of the pipeline inside the specified container image runtime environment
 
+| ``with_secrets(ArrayList secrets, Closure body)``
+| helper function that allows for universal credential binding for other libraries to consolidate their secrets
+
 |===
 
 .Lifecycle Hooks
 |===
-| Step | Hook | Purpose 
+| Step | Hook | Purpose
 
 | archive_pipeline_config()
 | `@Init`
@@ -23,7 +26,7 @@ The SDP library provides helper steps used by multiple libraries within sdp-libr
 
 | create_workspace_stash()
 | `@Validate`
-| If the pipeline job is a Multibranch Project, checkout the source code.  In either case, save a stash called "workspace" for other libraries to consume. 
+| If the pipeline job is a Multibranch Project, checkout the source code.  In either case, save a stash called "workspace" for other libraries to consume.
 
 |===
 
@@ -35,7 +38,7 @@ The SDP library provides helper steps used by multiple libraries within sdp-libr
 
 | images.registry
 | This sets the registry the sdp library expects to find its Docker images
-| 
+|
 
 | images.repository
 | The first https://forums.docker.com/t/docker-registry-v2-spec-and-repository-naming-rule/5466[path component] in the repository name, e.g. if your images follow the format ``my-registry.com/sdp/*``, this would be *sdp*
@@ -43,11 +46,24 @@ The SDP library provides helper steps used by multiple libraries within sdp-libr
 
 | sdp.images.cred
 | Credentials used for the repository where different docker pipeline tools are stored
-| 
+|
 
 | sdp.images.docker_args
 | Arguments to use when starting the container. Uses the same flags as `docker run`
-| 
+|
+
+| secrets.<key>
+| A jenkins secret that will be bound with as a credential in libraries that use `with_secrets` when the secret is passed to the configuration
+|
+
+| secrets.<key>.credentialsId
+| Jenkins credential ID that the secret refers to
+|
+
+| secrets.<key>.<some_other_field>
+| Each secret implicitly figures out the sort of binding it will require when used `withCredentials`, the additional fields are required for this field. Visit https://www.jenkins.io/doc/pipeline/steps/credentials-binding/
+| Note: All common credentials are supported now, if a plugin provides a new credential, it may not be supported yet. Make a pull request to support it!
+|
 
 |===
 
@@ -63,16 +79,35 @@ Unlike the Docker Library, the value in "registry" _does_ include the protocol (
 libraries{
   sdp{
     images{
-      registry = "https://docker.pkg.github.com" <1>
+      registry   = "https://docker.pkg.github.com" <1>
       repository = "boozallen/sdp-images" <2>
-      cred = "github" <3>
+      cred       = "github" <3>
     }
+  }
+}
+
+secrets{ <4>
+  someSecretText{ <5>
+    credentialsId = "someCredential"
+    variable     = "SOME_BINDING"
+  }
+  someUserPasswordCred{ <6>
+    credentialsId     = "someUserCred"
+    usernameVariable = "USERNAME_BINDING"
+    passwordVariable = "PASSWORD_BINDING"
+  }
+  someUserPasswordAsString{
+    credentialId = "someUserCred"
+    variable     = "SOME_COLON_SEPERATED_BINDING"
   }
 }
 ----
 <1> the container registry that holds the SDP container images
 <2> the container image repository that holds the SDP container images
 <3> A jenkins credential ID to authenticate to the container registry
+<4> For libraries implementing `with_secrets` as a means of handling credential bindings
+<5> A secret text credential binding example
+<6> A usernamePassword credential binding example
 
 == External Dependencies
 

--- a/libraries/sdp/steps/with_secrets.groovy
+++ b/libraries/sdp/steps/with_secrets.groovy
@@ -201,7 +201,7 @@ Map resolveSecrets(Map secrets, Map resolvers) {
             .tokenize('.')
             .pop()
 
-        def resolver = resolvers.get(clazz, 'Unknown')
+        def resolver = resolvers.get(clazz, resolvers['Unknown'])
 
         [key, resolver(secret)]
     }

--- a/libraries/sdp/steps/with_secrets.groovy
+++ b/libraries/sdp/steps/with_secrets.groovy
@@ -1,0 +1,208 @@
+package libraries.sdp
+
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.Credentials
+import com.cloudbees.plugins.credentials.CredentialsProvider
+
+void call(ArrayList secretKeys, Closure body) {
+    // Handling nulls, library providers can pass config.secrets blindly
+    secretKeys = secretKeys ?: []
+
+    if (!(secretKeys instanceof ArrayList)) error "with_secrets - ArrayList expected"
+
+    Map resolvers = [
+        AWSCredentialsImpl: { secret ->
+            String accessKeyVariable = secret.get('accessKeyVariable', 'AWS_ACCESS_KEY_ID')
+            String secretKeyVariable = secret.get('secretKeyVariable', 'AWS_SECRET_ACCESS_KEY')
+
+            [
+                $class: 'AmazonWebServicesCredentialsBinding',
+                accessKeyVariable: accessKeyVariable,
+                secretKeyVariable: secretKeyVariable,
+                credentialsId: secret.credentialsId
+            ]
+        },
+        BasicSSHUserPrivateKey: { secret -> sshUserPrivateKey(secret) },
+        CertificateCredentialsImpl: { secret -> certificate(secret) },
+        DockerServerCredentials: { secret -> dockerCert(secret) },
+        FileCredentialsImpl: { secret ->
+            String type = secret.remove('type')
+
+            type == 'file' ? file(secret) : zip(secret)
+        },
+        StringCredentialsImpl: { secret -> string(secret) },
+        UsernamePasswordCredentialsImpl: { secret -> secret.variable ? usernameColonPassword(secret) : usernamePassword(secret) }
+    ]
+
+    Map secrets = jte.pipelineConfig.secrets ?: [:]
+
+    ArrayList missing = secretKeys
+        .findAll { key -> !secrets.containsKey(key) }
+        .collect { key -> "- ${key}" }
+
+    if (missing) {
+        missing.add(0, "[ERROR] Secret configuration missing secret(s) specified:")
+
+        error missing.join('\n')
+    }
+
+    secrets = secretKeys
+        .collectEntries { key -> [key, secrets[key]] }
+
+    ArrayList credentials = this.resolveSecrets(secrets, resolvers).values()
+
+    withCredentials(credentials, body)
+}
+
+@Validate
+void validate() {
+    Map secrets = jte.pipelineConfig.secrets ?: [:]
+
+    ArrayList missing = secrets
+        .findAll { _, secret -> !secret.containsKey('credentialsId') }
+        .collect { name, _ -> "- ${name}" }
+
+    if (missing) {
+        missing.add(0, "[ERROR] The following secrets are missing 'credentialsId':")
+
+        error missing.join('\n')
+    }
+
+    def checkRequired = { params ->
+        ArrayList keys = params.secret.keySet()
+
+        ArrayList unexpected = keys.findAll { !(it in params.allowed) }
+
+        ArrayList errors = params.required
+            .findAll { !(it in keys) }
+            .collect { "Required key '${it}' not passed" }
+
+        if (unexpected) {
+            errors << "Unexpected keys passed: ${unexpected}"
+            errors << "Allowed keys: ${params.allowed}"
+        }
+
+        return errors
+    }
+
+    // credentialsId is checked for above, required = required - credentialsId
+    Map resolvers = [
+        AWSCredentialsImpl: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'accessKeyVariable', 'secretKeyVariable'],
+                required: [],
+                secret: secret
+            ]
+
+            checkRequired(params)
+        },
+        BasicSSHUserPrivateKey: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'keyFileVariable', 'usernameVariable', 'passwordVariable'],
+                required: ['keyFileVariable'],
+                secret: secret
+            ]
+
+            checkRequired(params)
+        },
+        DockerServerCredentials: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'variable'],
+                required: ['variable'],
+                secret: secret
+            ]
+
+            checkRequired(params)
+        },
+        CertificateCredentialsImpl: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'aliasVariable', 'keystoreVariable', 'passwordVariable'],
+                required: ['keystoreVariable'],
+                secret: secret
+            ]
+
+            checkRequired(params)
+        },
+        FileCredentialsImpl: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'variable', 'type'],
+                required: ['variable', 'type'],
+                secret: secret
+            ]
+
+            errors = checkRequired(params)
+
+            ArrayList allowedTypes = ['file', 'zip']
+
+            if (secret.type && !(secret.type in allowedTypes)) errors << "The key 'type' must be in ${allowedTypes}"
+
+            errors
+        },
+        StringCredentialsImpl: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'variable'],
+                required: ['variable'],
+                secret: secret
+            ]
+
+            checkRequired(params)
+        },
+        UsernamePasswordCredentialsImpl: { secret ->
+            Map params = [
+                allowed: ['credentialsId', 'variable', 'usernameVariable', 'passwordVariable'],
+                required: [],
+                secret: secret
+            ]
+
+            ArrayList errors = checkRequired(params)
+
+            boolean colonSecret     = 'variable' in secret
+            boolean seperatedSecret = ('usernameVariable' in secret || 'passwordVariable' in secret)
+            boolean userPassSecret  = ('usernameVariable' in secret && 'passwordVariable' in secret)
+
+            if (secret.size() == 1 || (colonSecret && seperatedSecret)) {
+                errors << "Either 'variable' or 'usernameVariable' and 'passwordVariable' should be specified"
+            }
+            else if (!userPassSecret) {
+                errors << "Both 'usernameVariable' and 'passwordVariable' must be specified"
+            }
+
+            return errors
+        },
+        NullObject: { secret -> ["Credential '${secret.credentialsId}' not found"] },
+        Unknown: { secret -> ["Credential '${secret.credentialsId}' is of an unsupported type"] }
+    ]
+
+    ArrayList errors = this.resolveSecrets(secrets, resolvers)
+        .findAll { _, errs -> errs }
+        .collect { key, errs ->
+            errs = errs.collect { "- ${it}" }
+            errs.add(0, "Secret '${key}' has errors:")
+
+            return errs.join('\n')
+        }
+
+    if (errors) {
+        errors.add(0, '[ERROR] Secrets have the following errors:')
+
+        error errors.join('\n')
+    }
+}
+
+Map resolveSecrets(Map secrets, Map resolvers) {
+    ArrayList credentials = CredentialsProvider.lookupCredentials(Credentials, Jenkins.get(), null, null)
+
+    secrets.collectEntries { key, secret ->
+        def cred = credentials.find { cred -> cred.id.equals(secret.credentialsId) }
+
+        String clazz = cred
+            .getClass()
+            .toString()
+            .tokenize('.')
+            .pop()
+
+        def resolver = resolvers.get(clazz, 'Unknown')
+
+        [key, resolver(secret)]
+    }
+}


### PR DESCRIPTION
# PR Details

Adds a helper function `with_secrets` which centralizes credential binding logic.

## Description

Instead of having each library roll their own credential logic, they can just call `with_secrets` and have the secrets be passed as a list of strings. Not all possible bindings are supported right now, only the common ones + AWS because I use it in my current project. I imagine as other libraries adopt it, if bindings beyond the ones here are needed, they can add the resolvers for validation and binding.

I resolve each credential by string to ensure it runs regardless of plugins installed by the Jenkins instance running it.

Example Usage:

pipeline_config.groovy
```
secrets{
  aws{
    credentialsId = 'aws-creds'
  }
}

libraries{
  sdp{...}
}
```
Jenkinsfile
```
node {
  with_secrets(['aws']) {
    sh 'aws s3 cp s3://some-bucket/something.txt .'
  }
}
```

## How Has This Been Tested

I manually tested it, and I'm using it at work.I'm not sure how'd I'd go about testing this using Jacoco. Would I have to mock the CredentialsProvider?

I created a credential of each type, and bound each of them to make sure they were working. Each worked in turn except for PKCS, but it was due to it being an uninitialized keystore, not due to the binding itself.

I used a dockerized Jenkins setup, https://www.jenkins.io/doc/book/installing/docker/

Jenkins 2.263.3
JTE 2.0.2

It's stand alone and currently effects nothing. Though, it relies on a declared toplevel block 'secrets', and so depending on other folks configurations it may be a breaking change for them... If it's accepted I'll be pushing a terraform library update using `with_secrets`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I am submitting this pull request to the appropriate branch
- [ ] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
