### PR TITLE
add npm-groovy-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin
 docs/html
 docs/node_modules
 .DS_Store
+node_modules

--- a/.groovylintrc.json
+++ b/.groovylintrc.json
@@ -1,0 +1,14 @@
+{
+    "extends": "recommended-jenkinsfile",
+    "rules": {
+        "LineLength": "off",
+        "SpaceBeforeOpeningBrace": "off",
+        "UnnecessaryGString": "off",
+        "BuilderMethodWithSideEffects": "off",
+        "FactoryMethodName": "off",
+        "formatting.Indentation": {
+            "spacesPerIndentLevel": 2,
+            "severity": "info"
+        }
+    }
+}

--- a/Justfile
+++ b/Justfile
@@ -52,6 +52,6 @@ release version branch=`git branch --show-current`:
   git push origin refs/tags/{{version}}
 
 # Run npm-groovy-lint
-lint: 
+lint library="": 
   [ ! -d "node_modules" ] && npm i || true
-  $(npm bin)/npm-groovy-lint -p libraries
+  $(npm bin)/npm-groovy-lint -p libraries/{{library}}

--- a/Justfile
+++ b/Justfile
@@ -50,3 +50,8 @@ release version branch=`git branch --show-current`:
   # push a tag for this release
   git tag {{version}}
   git push origin refs/tags/{{version}}
+
+# Run npm-groovy-lint
+lint: 
+  [ ! -d "node_modules" ] && npm i || true
+  $(npm bin)/npm-groovy-lint -p libraries

--- a/libraries/a11y/resources/error.txt
+++ b/libraries/a11y/resources/error.txt
@@ -1,0 +1,6 @@
+A11y Library needs the target url.
+libraries{
+  a11y{
+    url = "https://example.com"
+  }
+}

--- a/libraries/a11y/steps/accessibility_compliance_test.groovy
+++ b/libraries/a11y/steps/accessibility_compliance_test.groovy
@@ -1,29 +1,19 @@
 /*
   Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
-  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+  This software package is licensed under the Booz Allen Public License.
+  The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
 */
-
 package libraries.a11y.steps
 
 void call(){
-
   stage "Accessibility Compliance Scan", {
-
     def url = env.FRONTEND_URL ?: config.url ?: {
-      error """
-      A11y Library needs the target url.
-      libraries{
-        a11y{
-          url = "https://example.com"
-        }
-      }
-      """
-    } ()
+      error resource("error.txt")
+    }()
 
     inside_sdp_image "a11y", {
       sh "a11ym -o accessibility_compliance ${url}"
       archive "accessibility_compliance/**"
     }
   }
-
 }

--- a/libraries/anchore/library_config.groovy
+++ b/libraries/anchore/library_config.groovy
@@ -1,14 +1,14 @@
 fields{
     required{
         cred = String
-        anchore_engine_url = String	
+        anchore_engine_url = String
     }
     optional{
-	image_wait_timeout = int
-	policy_id = String	
-	archive_only = Boolean
-	bail_on_fail = Boolean
-	perform_vulnerability_scan = Boolean
-	perform_policy_evaluation = Boolean
+    image_wait_timeout = int
+    policy_id = String
+    archive_only = Boolean
+    bail_on_fail = Boolean
+    perform_vulnerability_scan = Boolean
+    perform_policy_evaluation = Boolean
     }
 }

--- a/libraries/anchore/steps/scan_container_image.groovy
+++ b/libraries/anchore/steps/scan_container_image.groovy
@@ -2,13 +2,12 @@
   Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
   This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
 */
-
 package libraries.anchore.steps
 
 import groovy.json.*
 
 void call(){
-    stage("Scanning Container Image: Anchore Scan"){
+  stage("Scanning Container Image: Anchore Scan"){
         def images = get_images_to_build()
         def anchore_engine_base_url = config.anchore_engine_url
         def anchore_policy_id = config.policy_id ?: null
@@ -19,252 +18,252 @@ void call(){
         def perf_policy_eval = true
 
         if (config.archive_only != null) {
-            archive_only = config.archive_only
+      archive_only = config.archive_only
         }
         if (config.bail_on_fail != null) {
-            bail_on_fail = config.bail_on_fail
+      bail_on_fail = config.bail_on_fail
         }
         if (config.perform_vulnerability_scan != null) {
-            perf_vuln_scan = config.perform_vulnerability_scan
+      perf_vuln_scan = config.perform_vulnerability_scan
         }
         if (config.perform_policy_evaluation != null) {
-            perf_policy_eval = config.perform_policy_evaluation 
+      perf_policy_eval = config.perform_policy_evaluation
         }
 
         println """
-        Library Configuration: 
+        Library Configuration:
           anchore_engine_url=${anchore_engine_base_url}
-          image_wait_timeout=${image_wait_timeout} 
-          policy_id=${anchore_policy_id} 
-          archive_only=${archive_only} 
-          bail_on_fail=${bail_on_fail} 
-          perform_policy_evaluation=${perf_policy_eval} 
+          image_wait_timeout=${image_wait_timeout}
+          policy_id=${anchore_policy_id}
+          archive_only=${archive_only}
+          bail_on_fail=${bail_on_fail}
+          perform_policy_evaluation=${perf_policy_eval}
           perform_vulnerability_scan=${perf_vuln_scan}
         """.stripIndent(4).trim()
-        
+
         node{
-            sh "mkdir -p anchore_results"
-            try {
-                withCredentials([usernamePassword(credentialsId: config.cred, passwordVariable: 'pass', usernameVariable: 'user')]) {      	
-                    images.each { img ->
-                        def input_image_fulltag = "${img.registry}/${img.repo}:${img.tag}"
+      sh "mkdir -p anchore_results"
+      try {
+        withCredentials([usernamePassword(credentialsId: config.cred, passwordVariable: 'pass', usernameVariable: 'user')]) {
+          images.each { img ->
+            def input_image_fulltag = "${img.registry}/${img.repo}:${img.tag}"
 
-                        success = false
-                        timeout(time: 1200, unit: 'SECONDS') {		  		  
-                            (success, new_image) = this.add_image(config, user, pass, input_image_fulltag)
-                        }
-                        if (success) {
-                            println("Image analysis successful")
-                        } else {
-                            error "Failed to add image to Anchore Engine for analysis"
-                        }
-
-                        if (perf_vuln_scan) {
-                            success = false
-                            timeout(time: 1200, unit: 'SECONDS') {
-                                (success, vulnerabilities) = this.get_image_vulnerabilities(config, user, pass, new_image)
-                            }
-                            if (success) {
-                                println("Image vulnerabilities report generation complete")
-                                if(!archive_only){
-                                    print_image_vulnerabilities(vulnerabilities)
-                                }
-                            } else {
-                                error "Failed to retrieve vulnerability results from Anchore Engine from analyzed image"
-                            }
-                        }
-
-                        if (perf_policy_eval) {
-                            success = false
-                            timeout(time: 1200, unit: 'SECONDS') {		  
-                                (success, evaluations) = get_image_evaluations(config, user, pass, new_image, input_image_fulltag)
-                            }
-                            if (success) {
-                                println("Image policy evaluation report generation complete")
-                                String final_action = evaluations.final_action
-                                if(!archive_only){
-                                    print_image_evalutations(evaluations)
-                                }
-                                if (bail_on_fail) {
-                                    // check policy eval final action and exit if STOP
-                                    if (final_action == "stop" || final_action == 'STOP') {
-                                        error "Anchore policy evaluation resulted in STOP action - failing scan."
-                                    }
-                                }
-                            } else {
-                                error "Failed to retrieve policy evaluation results from Anchore Engine from analyzed image"
-                            }		    
-                        }
-                    }
-                }
-            } catch (any) {
-                throw any
-            } finally {
-                archiveArtifacts allowEmptyArchive: true, artifacts: 'anchore_results/'
+            success = false
+            timeout(time: 1200, unit: 'SECONDS') {
+              (success, new_image) = this.add_image(config, user, pass, input_image_fulltag)
             }
+            if (success) {
+              println("Image analysis successful")
+                        } else {
+              error "Failed to add image to Anchore Engine for analysis"
+            }
+
+            if (perf_vuln_scan) {
+              success = false
+              timeout(time: 1200, unit: 'SECONDS') {
+                (success, vulnerabilities) = this.get_image_vulnerabilities(config, user, pass, new_image)
+              }
+              if (success) {
+                println("Image vulnerabilities report generation complete")
+                if (!archive_only){
+                  print_image_vulnerabilities(vulnerabilities)
+                }
+                            } else {
+                error "Failed to retrieve vulnerability results from Anchore Engine from analyzed image"
+              }
+            }
+
+            if (perf_policy_eval) {
+              success = false
+              timeout(time: 1200, unit: 'SECONDS') {
+                (success, evaluations) = get_image_evaluations(config, user, pass, new_image, input_image_fulltag)
+              }
+              if (success) {
+                println("Image policy evaluation report generation complete")
+                String final_action = evaluations.final_action
+                if (!archive_only){
+                  print_image_evalutations(evaluations)
+                }
+                if (bail_on_fail) {
+                  // check policy eval final action and exit if STOP
+                  if (final_action == "stop" || final_action == 'STOP') {
+                    error "Anchore policy evaluation resulted in STOP action - failing scan."
+                  }
+                }
+                            } else {
+                error "Failed to retrieve policy evaluation results from Anchore Engine from analyzed image"
+              }
+            }
+          }
         }
-    }
+            } catch (any) {
+        throw any
+            } finally {
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'anchore_results/'
+      }
+        }
+  }
 }
 
 def parse_json(input_file) {
-    return readJSON(file: "${input_file}")
+  return readJSON(file: "${input_file}")
 }
 
 def add_image(config, user, pass, input_image_fulltag) {
-    String anchore_engine_base_url = config.anchore_engine_url
-    int anchore_image_wait_timeout = config.image_wait_timeout ?: 300
-    Boolean done = false
-    Boolean success = false
-    def ret_image = null
-    String url
-    String image_digest
-    def input_image = [tag: "${input_image_fulltag}"]
-    def input_image_json = JsonOutput.toJson(input_image)
-    http_result = "new_anchore_image.json"
-    try {
-        url = "${anchore_engine_base_url}/images"
-        sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -X POST -o ${http_result} '${url}' -d '${input_image_json}' 2>curl.err"
-        def new_image = this.parse_json(http_result)[0]
-        image_digest = new_image.imageDigest
-        if (!image_digest) {
-            throw new Exception("Error response from Anchore Engine")
-        }
+  String anchore_engine_base_url = config.anchore_engine_url
+  int anchore_image_wait_timeout = config.image_wait_timeout ?: 300
+  Boolean done = false
+  Boolean success = false
+  def ret_image = null
+  String url
+  String image_digest
+  def input_image = [tag: "${input_image_fulltag}"]
+  def input_image_json = JsonOutput.toJson(input_image)
+  http_result = "new_anchore_image.json"
+  try {
+    url = "${anchore_engine_base_url}/images"
+    sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -X POST -o ${http_result} '${url}' -d '${input_image_json}' 2>curl.err"
+    def new_image = this.parse_json(http_result)[0]
+    image_digest = new_image.imageDigest
+    if (!image_digest) {
+      throw new Exception("Error response from Anchore Engine")
+    }
     } catch (any) {
-        try {
-            sh "cat curl.err ${http_result}"    
-        } catch (ignore) {}
-        throw any
+    try {
+      sh "cat curl.err ${http_result}"
+        } catch (ignore) { }
+    throw any
     }
 
-    try {
-        url = "${anchore_engine_base_url}/images/${image_digest}"
-        timeout(time: anchore_image_wait_timeout, unit: 'SECONDS') {
-            while(!done) {
-                http_result = "new_anchore_image_check.json"
-                try {
-                    sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -X GET -o ${http_result} '${url}' 2>curl.err"
-                    def new_image_check = this.parse_json(http_result)[0]
-                    if (new_image_check.analysis_status == "analyzed") {
-                        done = true
-                        success = true
-                        ret_image = new_image_check
-                    } else if ( new_image_check.analysis_status == "analysis_failed") {
-                        done = true
-                        success = false
-                    } else {
-                        println("image not yet analyzed - status is ${new_image_check.analysis_status}")
-                        sleep 5
-                    }
-                } catch (any) {
-                    success = false
-                    done = true
-                    throw any
-                } 
-            }
-        }
-    } catch (any) {
-        println("Timed out or error waiting for image to reach analyzed state")
-        success = false
-        ret_image = null
+  try {
+    url = "${anchore_engine_base_url}/images/${image_digest}"
+    timeout(time: anchore_image_wait_timeout, unit: 'SECONDS') {
+      while (!done) {
+        http_result = "new_anchore_image_check.json"
         try {
-            sh "cat curl.err ${http_result}"       
-        } catch (ignore) {}
-    } 
-    return [success, ret_image]
-}
+          sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -X GET -o ${http_result} '${url}' 2>curl.err"
+          def new_image_check = this.parse_json(http_result)[0]
+          if (new_image_check.analysis_status == "analyzed") {
+            done = true
+            success = true
+            ret_image = new_image_check
+                    } else if ( new_image_check.analysis_status == "analysis_failed") {
+            done = true
+            success = false
+                    } else {
+            println("image not yet analyzed - status is ${new_image_check.analysis_status}")
+            sleep 5
+          }
+                } catch (any) {
+          success = false
+          done = true
+          throw any
+        }
+      }
+    }
+    } catch (any) {
+    println("Timed out or error waiting for image to reach analyzed state")
+    success = false
+    ret_image = null
+    try {
+      sh "cat curl.err ${http_result}"
+        } catch (ignore) { }
+    }
+  return [success, ret_image]
+  }
 
 def get_image_vulnerabilities(config, user, pass, image) {
-    String anchore_engine_base_url = config.anchore_engine_url
-    Boolean success = false
-    def vulnerabilities = null
-    ArrayList ret_vulnerabilities = null
-    String url = null
+  String anchore_engine_base_url = config.anchore_engine_url
+  Boolean success = false
+  def vulnerabilities = null
+  ArrayList ret_vulnerabilities = null
+  String url = null
 
-    http_result = "anchore_results/anchore_vulnerabilities.json"
-    try {
-        url = "${anchore_engine_base_url}/images/${image.imageDigest}/vuln/all?vendor_only=True"
-        sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -o ${http_result} '${url}' 2>curl.err"
-        vulnerabilities = this.parse_json(http_result)
-        if (vulnerabilities.containsKey("vulnerabilities")) {
-            ret_vulnerabilities = vulnerabilities.vulnerabilities
-            success = true
+  http_result = "anchore_results/anchore_vulnerabilities.json"
+  try {
+    url = "${anchore_engine_base_url}/images/${image.imageDigest}/vuln/all?vendor_only=True"
+    sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -o ${http_result} '${url}' 2>curl.err"
+    vulnerabilities = this.parse_json(http_result)
+    if (vulnerabilities.containsKey("vulnerabilities")) {
+      ret_vulnerabilities = vulnerabilities.vulnerabilities
+      success = true
         } else {
-            throw new Exception ("ERROR response from Anchore Engine")
-        }
-    } catch (any) {
-        try {
-            sh "cat curl.err ${http_result}"           
-        } catch (ignore) {}
-        throw any
+      throw new Exception ("ERROR response from Anchore Engine")
     }
-    return [success, ret_vulnerabilities]
-}
+    } catch (any) {
+    try {
+      sh "cat curl.err ${http_result}"
+        } catch (ignore) { }
+    throw any
+    }
+  return [success, ret_vulnerabilities]
+  }
 
 void print_image_vulnerabilities(vulnerabilities){
-    vulnerability_result =  "Anchore Image Scan Vulnerability Results\n"
-    vulnerability_result += "****************************************\n\n"
-    if (vulnerabilities) {
-        vulnerability_result += "VulnID".padRight(16, ' ')+"\t" + "Severity".padRight(12, ' ') + "\t" + "Package".padRight(30, ' ') + "\t" + "Type".padRight(6, ' ') + "\t" + "Fix Available".padRight(12, ' ') + "\tLink\n"
-        vulnerabilities.each { vuln ->
-            vid = vuln.vuln.padRight(16, ' ')
-            vsev = vuln.severity.padRight(12, ' ')
-            vpkg = vuln.package.padRight(30, ' ') 
-            vtype = vuln.package_type.padRight(6, ' ')
-            vfix = vuln.fix.padRight(12, ' ')
-            vurl = vuln.url
-            vulnerability_result += "${vid}\t${vsev}\t${vpkg}\t${vtype}\t${vfix}\t${vurl}\n"
-        }
-    } else {
-        vulnerability_result += "No vulnerabilities detected\n"
+  vulnerability_result =  "Anchore Image Scan Vulnerability Results\n"
+  vulnerability_result += "****************************************\n\n"
+  if (vulnerabilities) {
+    vulnerability_result += "VulnID".padRight(16, ' ') + "\t" + "Severity".padRight(12, ' ') + "\t" + "Package".padRight(30, ' ') + "\t" + "Type".padRight(6, ' ') + "\t" + "Fix Available".padRight(12, ' ') + "\tLink\n"
+    vulnerabilities.each { vuln ->
+      vid = vuln.vuln.padRight(16, ' ')
+      vsev = vuln.severity.padRight(12, ' ')
+      vpkg = vuln.package.padRight(30, ' ')
+      vtype = vuln.package_type.padRight(6, ' ')
+      vfix = vuln.fix.padRight(12, ' ')
+      vurl = vuln.url
+      vulnerability_result += "${vid}\t${vsev}\t${vpkg}\t${vtype}\t${vfix}\t${vurl}\n"
     }
-    println vulnerability_result
+    } else {
+    vulnerability_result += "No vulnerabilities detected\n"
+  }
+  println vulnerability_result
 }
 
 def get_image_evaluations(config, user, pass, image, input_image_fulltag) {
-    String anchore_engine_base_url = config.anchore_engine_url
-    String anchore_policy_id = config.policy_id ?: null
-    Boolean success = false
-    def evaluations = null
-    def ret_evaluations = null
-    String url = null
+  String anchore_engine_base_url = config.anchore_engine_url
+  String anchore_policy_id = config.policy_id ?: null
+  Boolean success = false
+  def evaluations = null
+  def ret_evaluations = null
+  String url = null
 
-    String image_digest = image.imageDigest
-    String image_id = image.image_detail[0].imageId
+  String image_digest = image.imageDigest
+  String image_id = image.image_detail[0].imageId
 
-    http_result = "anchore_results/anchore_policy_evaluations.json"
-    try {
-        url = "${anchore_engine_base_url}/images/${image_digest}/check?history=false&detail=true&tag=${input_image_fulltag}"
-        if (anchore_policy_id) {
-            url += "&policyId=${anchore_policy_id}"
-        }
-        sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -o ${http_result} '${url}' 2>curl.err"
-        evaluations = this.parse_json(http_result)
-        ret_evaluations = evaluations[0]["${image_digest}"]["${input_image_fulltag}"]["detail"]["result"]["result"][0]["${image_id}"]["result"]
-        success = true
+  http_result = "anchore_results/anchore_policy_evaluations.json"
+  try {
+    url = "${anchore_engine_base_url}/images/${image_digest}/check?history=false&detail=true&tag=${input_image_fulltag}"
+    if (anchore_policy_id) {
+      url += "&policyId=${anchore_policy_id}"
+    }
+    sh "curl -u '${user}':'${pass}' -H 'content-type: application/json' -o ${http_result} '${url}' 2>curl.err"
+    evaluations = this.parse_json(http_result)
+    ret_evaluations = evaluations[0]["${image_digest}"]["${input_image_fulltag}"]["detail"]["result"]["result"][0]["${image_id}"]["result"]
+    success = true
     } catch (any) {
-        try {
-            sh "cat curl.err ${http_result}"               
-        } catch (ignore) {}
-        throw any
+    try {
+      sh "cat curl.err ${http_result}"
+        } catch (ignore) { }
+    throw any
     }
 
-    return [success, ret_evaluations]
-}
+  return [success, ret_evaluations]
+  }
 
 void print_image_evalutations(evaluations){
-    if (evaluations) {
-        evaluation_result =  "Anchore Image Scan Policy Evaluation Results\n"
-        evaluation_result += "********************************************\n"
-        evaluation_result += "Gate".padRight(12, ' ')+"\t" + "Trigger".padRight(12, ' ') + "\t" + "Action".padRight(6, ' ') + "\t" + "Details\n"
-        evaluations.rows.each { eval ->
-            egate = eval[3].padRight(12, ' ')
-            etrigger = eval[4].padRight(12, ' ')
-            eaction = eval[6].padRight(6, ' ')
-            edetail = eval[5]
-            evaluation_result += "${egate}\t${etrigger}\t${eaction}\t${edetail}"
-        }
-    } else {
-        evaluation_result = "No evaluations to report\n"
+  if (evaluations) {
+    evaluation_result =  "Anchore Image Scan Policy Evaluation Results\n"
+    evaluation_result += "********************************************\n"
+    evaluation_result += "Gate".padRight(12, ' ') + "\t" + "Trigger".padRight(12, ' ') + "\t" + "Action".padRight(6, ' ') + "\t" + "Details\n"
+    evaluations.rows.each { eval ->
+      egate = eval[3].padRight(12, ' ')
+      etrigger = eval[4].padRight(12, ' ')
+      eaction = eval[6].padRight(6, ' ')
+      edetail = eval[5]
+      evaluation_result += "${egate}\t${etrigger}\t${eaction}\t${edetail}"
     }
-    println evaluation_result
+    } else {
+    evaluation_result = "No evaluations to report\n"
+  }
+  println evaluation_result
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,634 @@
+{
+  "name": "sdp-libraries",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "amplitude": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/amplitude/-/amplitude-5.1.5.tgz",
+      "integrity": "sha512-vqI74tvgYDAm+/m+Yc5A/qhCroe4QNICAVPCcz7PMZyVbPOjtBoeKX5Hk8sgDVCKxoNABXrzhkkZ5S2kXSvPHg==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        }
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
+    "cli-progress": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
+      "integrity": "sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "string-width": "^4.2.0"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
+    "command-exists-promise": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/command-exists-promise/-/command-exists-promise-2.0.2.tgz",
+      "integrity": "sha512-T6PB6vdFrwnHXg/I0kivM3DqaCGZLjjYSOe0a5WgFKcz1sOnmOeIjnhQPXVXX3QjVbLyTJ85lJkX6lUpukTzaA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "decode-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decode-html/-/decode-html-2.0.0.tgz",
+      "integrity": "sha1-fQqIfORCgOYJeKcH67f4CB/WHqo=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "find-java-home": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.2.0.tgz",
+      "integrity": "sha512-eDSGAFxAbKqnlhARU0xfHhoNhsAhnJ/4q+pctoNIOmJxR7uJaLPg+wd9ngA+hDee8l+oytxOERKzqe8mLA57OQ==",
+      "dev": true,
+      "requires": {
+        "which": "~1.0.5",
+        "winreg": "~1.2.2"
+      }
+    },
+    "find-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "java-caller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.2.4.tgz",
+      "integrity": "sha512-c6pG483U+KKkP0Qz8BN6Lj+EPShFHHYHZhfnnTYG1JaSpMCguZd2xUSjOx552Z95JFrKZD9Q1ODul7OF4/W/RQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "njre": "^0.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "njre": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/njre/-/njre-0.2.0.tgz",
+      "integrity": "sha512-+Wq8R6VmjK+jI8a9NdzfU6Vh50r3tjsdvl5KJE1OyHeH8I/nx5Ptm12qpO3qNUbstXuZfBDgDL0qQZw9JyjhMw==",
+      "dev": true,
+      "requires": {
+        "command-exists-promise": "^2.0.2",
+        "node-fetch": "^2.5.0",
+        "tar": "^4.4.8",
+        "yauzl": "^2.10.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
+    "npm-groovy-lint": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-8.1.0.tgz",
+      "integrity": "sha512-VPBv0tZlv2pnfbOB+IBsPuZCKDpT1TnJYcl7nnJ1/LCy1xjld9twWyd3XePQcMhjQ6naz3MEW/ZGzqUj8ZlGLg==",
+      "dev": true,
+      "requires": {
+        "amplitude": "^5.1.2",
+        "ansi-colors": "^4.1.1",
+        "axios": "^0.19.2",
+        "cli-progress": "^3.6.0",
+        "debug": "^4.1.1",
+        "decode-html": "^2.0.0",
+        "find-java-home": "^1.1.0",
+        "find-package-json": "^1.2.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.6",
+        "import-fresh": "^3.2.1",
+        "ip": "^1.1.5",
+        "java-caller": "^2.2.4",
+        "optionator": "^0.8.3",
+        "semver": "^7.1.3",
+        "strip-json-comments": "^3.0.1",
+        "uuid": "^8.2.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          },
+          "dependencies": {
+            "follow-redirects": {
+              "version": "1.13.3",
+              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+              "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+              "dev": true
+            }
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
+            }
+          }
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs=",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sdp-libraries",
+  "version": "1.0.0",
+  "description": "Placeholder package.json ",
+  "author": "Steven Terrana",
+  "license": "Booz Allen Public License (BAPL)",
+  "scripts": {
+    "preinstall": "npx npm-force-resolutions"
+  },
+  "devDependencies": {
+    "npm-groovy-lint": "^8.1.0"
+  },
+  "resolutions": {
+    "axios": "^0.21.1"
+  }
+}


### PR DESCRIPTION
# PR Details

Adds `npm-groovy-lint` support to the `Justfile` and creates a base rule profile in `.groovylintrc.json`. 

Fixes for the libraries will (should) happen in subsequent PRs. Issues will be created to track each library. 

Once libraries have been standardized, we'll enable linting via GH Action and make it required. 