### PR TITLE
patch `git` library to support JTE 2.1 in a backwards compatible way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin
 docs/html
 docs/node_modules
 .DS_Store
+node_modules

--- a/docs/modules/ROOT/pages/libraries/sdp.adoc
+++ b/docs/modules/ROOT/pages/libraries/sdp.adoc
@@ -11,6 +11,9 @@ The SDP library provides helper steps used by multiple libraries within sdp-libr
 | ``inside_sdp_images(String image, Closure body)``
 | helper function that wraps ``docker.image(<image>).inside{}`` to execute a portion of the pipeline inside the specified container image runtime environment
 
+| ``jteVersion``
+| a multi-method step that provides utilities for determining the current JTE version. more docs below. 
+
 |===
 
 .Lifecycle Hooks
@@ -74,11 +77,51 @@ libraries{
 <2> the container image repository that holds the SDP container images
 <3> A jenkins credential ID to authenticate to the container registry
 
+== `jteVersion`
+
+`jteVersion` is a multi-method step that provides utilities for determining the current JTE version. This is particularly useful when making changes to support backwards compatibility. 
+
+.Methods
+|===
+| Method | Description
+
+| `jteVersion.get()`
+| returns the current JTE version
+
+| `jteVersion.lessThan(String version)`
+| returns true if the current JTE version is less than the parameter
+
+| `jteVersion.lessThanOrEqualTo(String version)`
+| returns true if the current JTE version is less than or equal to the parameter
+
+| `jteVersion.greatherThan(String version)`
+| returns true if the current JTE version is greater than the parameter
+
+| `jteVersion.greaterThanOrEqualTo(String version)`
+| returns true if the current JTE version is greater than or equal to the parameter
+
+| `jteVersion.equalTo(String version)`
+| returns true if the current JTE version is equal to the parameter
+
+|===
+
+For example, 
+
+[source, groovy]
+----
+if (jteVersion.lessThan("2.1")){
+  // code to run if current installed version is < 2.1
+} else { 
+  // code to run if current installed version is >= 2.1
+}
+----
+
 == External Dependencies
 
 * A Docker registry must be setup and configured. Credentials to the registry are also needed.
 * A repository for the image being used by the given library is expected to be in the given registry.
 * The repository name for the pipeline tools' images should be in the format  _"${images.registry}/${images.repository}/tool-name"_
+* The Pipeline Utility Steps plugin is required 
 
 == Troubleshooting
 

--- a/libraries/git/steps/git_distributions.groovy
+++ b/libraries/git/steps/git_distributions.groovy
@@ -68,5 +68,5 @@ void init_env(){
 }
 
 def fetch(){
-    return getBinding().getStep(env.GIT_LIBRARY_DISTRUBITION)
+  return getStep(env.GIT_LIBRARY_DISTRUBITION)
 }

--- a/libraries/sdp/steps/getStep.groovy
+++ b/libraries/sdp/steps/getStep.groovy
@@ -1,0 +1,31 @@
+/*
+  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. 
+  The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+package libraries.sdp.steps
+
+def getStep(String stepName){
+  if(jteVersion.lessThanOrEqualTo("2.0.4")){
+    return getBinding().getStep(stepName)
+  } else { 
+    return this.getStepFromCollector(stepName)
+  }
+}
+
+@NonCPS
+def getStepFromCollector(String stepName){
+  try{
+    Class collector = Class.forName("org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector")
+    List steps = collector.current().getStep(stepName)
+    if(steps.size() == 0){
+      error "Step '${stepName}' not found."
+    } else if (steps.size() > 1){
+      error "Ambiguous step name '${stepName}'. Found multiple steps by that name."
+    } else {
+      return steps.first()
+    }
+  }catch(ClassNotFoundException ex){
+    error "can't find the TemplatePrimitiveCollector class. That's odd. current JTE version is '${jteVersion.get()}'. You should submit an issue at https://github.com/jenkinsci/templating-engine-plugin/issues/new/choose"
+  }
+}

--- a/libraries/sdp/steps/jteVersion.groovy
+++ b/libraries/sdp/steps/jteVersion.groovy
@@ -1,0 +1,42 @@
+/*
+  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. 
+  The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+package libraries.sdp.steps
+
+import jenkins.model.Jenkins
+import groovy.transform.Field
+
+@Field static private final int LESS_THAN = -1
+@Field static private final int GREATER_THAN = 1
+@Field static private final int EQUAL_TO = 0
+
+String get(){
+  return Jenkins.get().pluginManager.getPlugin("templating-engine").version
+}
+
+boolean lessThan(String version){
+  return compare(this.get(), version) == LESS_THAN
+}
+
+boolean greaterThan(String version){
+  return compare(this.get(), version) == GREATER_THAN
+}
+
+boolean equalTo(String version){
+  return compare(this.get(), version) == EQUAL_TO
+}
+
+boolean lessThanOrEqualTo(String version){
+  return compare(this.get(), version) in [LESS_THAN, EQUAL_TO]
+}
+
+boolean greaterThanOrEqualTo(String version){
+  return compare(this.get(), version) in [LESS_THAN, GREATER_THAN]
+}
+
+int compare(String v1, String v2){
+  return compareVersions(v1: v1, v2: v2)
+}
+

--- a/test/JTEPipelineSpecification.groovy
+++ b/test/JTEPipelineSpecification.groovy
@@ -28,6 +28,7 @@ public class JTEPipelineSpecification extends JenkinsPipelineSpecification {
         // define auto importing of JTE hook annotations
         ImportCustomizer ic = new ImportCustomizer()
         ic.addStarImports("org.boozallen.plugins.jte.init.primitives.hooks")
+        ic.addImports("com.cloudbees.groovy.cps.NonCPS")
         cc.addCompilationCustomizers(ic) 
         script_engine.setConfig(cc)
 


### PR DESCRIPTION
# PR Details

* Patches the `git` library's call to `getBinding().getStep()` which disappeared in JTE 2.1
* adds a `jteVersion` step which supports logical operations for working around the current JTE version
* adds a `getStep` utility in the sdp libraries since all that logic shouldn't be in the `git` library

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
