### PR TITLE
adding add_registry_creds for anchore

### DIFF
--- a/docs/modules/ROOT/pages/libraries/anchore.adoc
+++ b/docs/modules/ROOT/pages/libraries/anchore.adoc
@@ -11,6 +11,9 @@ The Anchore library implements a comprehensive container image vulnerability and
 | ``scan_container_image()``
 | Scan the container image built and pushed to a registry, with the image tag identifiers to scan fetched by get_images_to_build()
 
+| ``add_registry_creds()``
+| Add docker registry credentials to Anchore if they do not already exist, so it can pull an image from a private registry. Can run this step before `scan_container_image` to ensure Anchore has access to an image in a private registry.
+
 |===
 
 == Library Configuration Options
@@ -59,6 +62,27 @@ The Anchore library implements a comprehensive container image vulnerability and
 | If set to true, cause the library to perform an Anchore Policy Evaluation compliance scan and generate a report.
 | true
 
+| docker_registry_credential_id
+| String
+| Credential id of private docker registry
+| true
+
+| docker_registry_name
+| String
+| Address of private docker registry
+| true
+
+| k8s_credential
+| String
+| Credential id of kubeconfig credential
+| true
+
+| k8s_context
+| String
+| Cluster context to use in kubeconfig
+| true
+
+
 |===
 
 
@@ -74,6 +98,10 @@ libraries{
     //bail_on_fail = false
     //perform_vulnerability_scan = true
     //perform_policy_evaluation = true
+    //docker_registry_credential_id = docker_registry
+    //docker_registry_name = ""
+    //k8s_credential
+    //k8s_context
   }
 }
 ----

--- a/libraries/anchore/library_config.groovy
+++ b/libraries/anchore/library_config.groovy
@@ -4,11 +4,15 @@ fields{
         anchore_engine_url = String	
     }
     optional{
-	image_wait_timeout = int
-	policy_id = String	
-	archive_only = Boolean
-	bail_on_fail = Boolean
-	perform_vulnerability_scan = Boolean
-	perform_policy_evaluation = Boolean
+        image_wait_timeout = int
+        policy_id = String	
+        archive_only = Boolean
+        bail_on_fail = Boolean
+        perform_vulnerability_scan = Boolean
+        perform_policy_evaluation = Boolean
+        docker_registry_credential_id = String
+        docker_registry_name = String
+        k8s_credential = String
+        k8s_context = String
     }
 }

--- a/libraries/anchore/steps/add_registry_creds.groovy
+++ b/libraries/anchore/steps/add_registry_creds.groovy
@@ -18,58 +18,55 @@ def generate_post_data(registry, registry_user, registry_password){
         ])
 }
 
-void call(app_env){
+void call(app_env = null){
     stage("Ensure Anchore has Docker Creds"){
 
         /*
         Docker registry creds for pulling helm image (has kubectl)
         */
-        def docker_registry_credential_id = app_env && app_env.docker_registry_credential_id ?: 
+        def docker_registry_credential_id = app_env?.docker_registry_credential_id   ?: 
                                                 config.docker_registry_credential_id ?: 
                                                 "docker_registry"
                                                 
-        def docker_registry_name = app_env && app_env.docker_registry_name ?: 
+        def docker_registry_name = app_env?.docker_registry_name    ?: 
                                         config.docker_registry_name ?: 
                                         ""
 
         /*
         k8s credential with kubeconfig 
         */
-        def k8s_credential = app_env && app_env.k8s_credential ?:
-                                config.k8s_credential  ?:
+        def k8s_credential = app_env?.k8s_credential  ?:
+                                config.k8s_credential ?:
                                 {error "Kubernetes Credential Not Defined"}()
         /*
         k8s context
         */
-        def k8s_context = app_env && app_env.k8s_context ?:
+        def k8s_context = app_env?.k8s_context ?:
                             config.k8s_context ?:
                             {error "Kubernetes Context Not Defined"}()
 
         /*
         Anchore engine url
         */
-        env.ANCHORE_ENGINE_URL = app_env && app_env.anchore_engine_url ?: 
+        env.ANCHORE_ENGINE_URL = app_env?.anchore_engine_url  ?: 
                                     config.anchore_engine_url ?: 
                                     {error "Anchore Engine Url Not Defined"}()
 
-        node{
+        try {
+            withCredentials([
+                usernamePassword(credentialsId: config.cred, usernameVariable: 'ANCHORE_USERNAME', passwordVariable: "ANCHORE_PASSWORD"),
+                usernamePassword(credentialsId: docker_registry_credential_id, usernameVariable: 'REGISTRY_USERNAME', passwordVariable: "REGISTRY_PASSWORD")
+            ]) {
+                inside_sdp_image "helm", { 
+                    withKubeConfig([credentialsId: k8s_credential , contextName: k8s_context]) {
+                        sh "curl --header \"Content-Type: application/json\" -X POST -u $ANCHORE_USERNAME:$ANCHORE_PASSWORD $ANCHORE_ENGINE_URL/registries -d '${generate_post_data(docker_registry_name, REGISTRY_USERNAME, REGISTRY_PASSWORD)}'"
 
-            try {
-                withCredentials([
-                    usernamePassword(credentialsId: config.cred, usernameVariable: 'ANCHORE_USERNAME', passwordVariable: "ANCHORE_PASSWORD"),
-                    usernamePassword(credentialsId: docker_registry_credential_id, usernameVariable: 'REGISTRY_USERNAME', passwordVariable: "REGISTRY_PASSWORD")
-                ]) {
-                    inside_sdp_image "helm", { 
-                        withKubeConfig([credentialsId: k8s_credential , contextName: k8s_context]) {
-                            sh "curl --header \"Content-Type: application/json\" -X POST -u $ANCHORE_USERNAME:$ANCHORE_PASSWORD $ANCHORE_ENGINE_URL/registries -d '${generate_post_data(docker_registry_name, REGISTRY_USERNAME, REGISTRY_PASSWORD)}'"
-
-                            sh 'curl -u $ANCHORE_USERNAME:$ANCHORE_PASSWORD $ANCHORE_ENGINE_URL/registries'
-                        }
+                        sh 'curl -u $ANCHORE_USERNAME:$ANCHORE_PASSWORD $ANCHORE_ENGINE_URL/registries'
                     }
                 }
-            } catch (e) {
-                println "anchore add_registry_creds step failed: $e"
             }
+        } catch (e) {
+            println "anchore add_registry_creds step failed: $e"
         }
     }
 }

--- a/libraries/anchore/steps/add_registry_creds.groovy
+++ b/libraries/anchore/steps/add_registry_creds.groovy
@@ -1,0 +1,75 @@
+/*
+  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+
+package libraries.anchore.steps
+
+import groovy.json.*
+
+def generate_post_data(registry, registry_user, registry_password){
+    return JsonOutput.toJson([
+            registry: "$registry",
+            registry_name: "$registry",
+            registry_type: 'docker_v2',
+            registry_user: "$registry_user",
+            registry_verify: true,
+            registry_pass: "$registry_password"
+        ])
+}
+
+void call(app_env){
+    stage("Ensure Anchore has Docker Creds"){
+
+        /*
+        Docker registry creds for pulling helm image (has kubectl)
+        */
+        def docker_registry_credential_id = app_env.docker_registry_credential_id ?: 
+                                                config.docker_registry_credential_id ?: 
+                                                "docker_registry"
+                                                
+        def docker_registry_name = app_env.docker_registry_name ?: 
+                                        config.docker_registry_name ?: 
+                                        ""
+
+        /*
+        k8s credential with kubeconfig 
+        */
+        def k8s_credential = app_env.k8s_credential ?:
+                                config.k8s_credential  ?:
+                                {error "Kubernetes Credential Not Defined"}()
+        /*
+        k8s context
+        */
+        def k8s_context = app_env.k8s_context ?:
+                            config.k8s_context ?:
+                            {error "Kubernetes Context Not Defined"}()
+
+        /*
+        Anchore engine url
+        */
+        env.ANCHORE_ENGINE_URL = app_env.anchore_engine_url ?: 
+                                    config.anchore_engine_url ?: 
+                                    {error "Anchore Engine Url Not Defined"}()
+
+        node{
+
+            try {
+                withCredentials([
+                    usernamePassword(credentialsId: config.cred, usernameVariable: 'ANCHORE_USERNAME', passwordVariable: "ANCHORE_PASSWORD"),
+                    usernamePassword(credentialsId: docker_registry_credential_id, usernameVariable: 'REGISTRY_USERNAME', passwordVariable: "REGISTRY_PASSWORD")
+                ]) {
+                    inside_sdp_image "helm", { 
+                        withKubeConfig([credentialsId: k8s_credential , contextName: k8s_context]) {
+                            sh "curl --header \"Content-Type: application/json\" -X POST -u $ANCHORE_USERNAME:$ANCHORE_PASSWORD $ANCHORE_ENGINE_URL/registries -d '${generate_post_data(docker_registry_name, REGISTRY_USERNAME, REGISTRY_PASSWORD)}'"
+
+                            sh 'curl -u $ANCHORE_USERNAME:$ANCHORE_PASSWORD $ANCHORE_ENGINE_URL/registries'
+                        }
+                    }
+                }
+            } catch (e) {
+                println "anchore add_registry_creds step failed: $e"
+            }
+        }
+    }
+}

--- a/libraries/anchore/steps/add_registry_creds.groovy
+++ b/libraries/anchore/steps/add_registry_creds.groovy
@@ -24,31 +24,31 @@ void call(app_env){
         /*
         Docker registry creds for pulling helm image (has kubectl)
         */
-        def docker_registry_credential_id = app_env.docker_registry_credential_id ?: 
+        def docker_registry_credential_id = app_env && app_env.docker_registry_credential_id ?: 
                                                 config.docker_registry_credential_id ?: 
                                                 "docker_registry"
                                                 
-        def docker_registry_name = app_env.docker_registry_name ?: 
+        def docker_registry_name = app_env && app_env.docker_registry_name ?: 
                                         config.docker_registry_name ?: 
                                         ""
 
         /*
         k8s credential with kubeconfig 
         */
-        def k8s_credential = app_env.k8s_credential ?:
+        def k8s_credential = app_env && app_env.k8s_credential ?:
                                 config.k8s_credential  ?:
                                 {error "Kubernetes Credential Not Defined"}()
         /*
         k8s context
         */
-        def k8s_context = app_env.k8s_context ?:
+        def k8s_context = app_env && app_env.k8s_context ?:
                             config.k8s_context ?:
                             {error "Kubernetes Context Not Defined"}()
 
         /*
         Anchore engine url
         */
-        env.ANCHORE_ENGINE_URL = app_env.anchore_engine_url ?: 
+        env.ANCHORE_ENGINE_URL = app_env && app_env.anchore_engine_url ?: 
                                     config.anchore_engine_url ?: 
                                     {error "Anchore Engine Url Not Defined"}()
 

--- a/libraries/kubernetes/steps/deploy_to.groovy
+++ b/libraries/kubernetes/steps/deploy_to.groovy
@@ -124,6 +124,6 @@ void push_config_update(values_file){
   echo "updating values file -> ${values_file}"
   git add: values_file
   git commit: "Updating ${values_file} for ${env.REPO_NAME} images"
-  git push
+  git "push"
 }
 


### PR DESCRIPTION
# PR Details

Adds method `add_registry_creds` in Anchore library. This method will add to Anchore private docker registry credentials, allowing Anchore to pull and scan images from this repository.

This PR also changes the `git push` to `git "push"` in the `deploy_to` step of the Kubernetes library. This is done because 'push' of `git push` no longer appears to be found.

## Description

Adding an optional `add_registry_creds` step in the Anchore library, with additional optional configuration items: 

```
        docker_registry_credential_id = String
        docker_registry_name = String
        k8s_credential = String
        k8s_context = String
```

These changes are opt-in, being fully reverse compatible with Anchore library usage prior to the commit.

This PR also includes updates to the Anchore documentation page.

## How Has This Been Tested

This new method has been tested in an sdp pipeline, on both fresh environments, and on repeated pipeline runs.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
