### PR TITLE
Docker enhancement with buildx

### DIFF
--- a/docs/modules/ROOT/pages/libraries/docker.adoc
+++ b/docs/modules/ROOT/pages/libraries/docker.adoc
@@ -25,7 +25,7 @@ The Docker library will build docker images and push them into a docker reposito
 
 |===
 
-== Example Configuration Snippet for Standard Docker builds
+== Example Configuration Snippet
 
 [source,groovy]
 ----
@@ -44,30 +44,6 @@ libraries{
       SOME_VALUE = "some-inline-value-here"
     }
   }
-}
-----
-
-== Example Configuration Snippet for buildx Docker builds
-
-[source,groovy]
-----
-libraries{
-  docker {
-        build_strategy = "buildx"
-        registry = "docker-registry.default.svc:5000"
-        cred = "docker_creds"
-        repo_path_prefix = "java"
-        buildx {
-            name {
-                build_args {
-                    BASE_IMAGE = "alpine:3.12"
-                }
-                platforms = ["linux/amd64","linux/arm64","linux/arm/v7"]
-                context = "."
-                useLatestTag = true                
-            }
-        }
-    }
 }
 ----
 == Configurations

--- a/docs/modules/ROOT/pages/libraries/docker.adoc
+++ b/docs/modules/ROOT/pages/libraries/docker.adoc
@@ -11,6 +11,9 @@ The Docker library will build docker images and push them into a docker reposito
 | ``build()``
 | builds a container image, tagging it with the Git SHA, and pushes the image to the defined registry
 
+| ``buildx()``
+| builds a multi-architecture image using buildx emulation, and pushes the image or images to the defined registry
+
 | ``get_images_to_build()``
 | inspects the source code repository based upon the configured ``build_strategy`` to determine which container images to build
 
@@ -22,7 +25,7 @@ The Docker library will build docker images and push them into a docker reposito
 
 |===
 
-== Example Configuration Snippet
+== Example Configuration Snippet for Standard Docker builds
 
 [source,groovy]
 ----
@@ -43,6 +46,30 @@ libraries{
   }
 }
 ----
+
+== Example Configuration Snippet for buildx Docker builds
+
+[source,groovy]
+----
+libraries{
+  docker {
+        build_strategy = "buildx"
+        registry = "docker-registry.default.svc:5000"
+        cred = "docker_creds"
+        repo_path_prefix = "java"
+        buildx {
+            name {
+                build_args {
+                    BASE_IMAGE = "alpine:3.12"
+                }
+                platforms = ["linux/amd64","linux/arm64","linux/arm/v7"]
+                context = "."
+                useLatestTag = true                
+            }
+        }
+    }
+}
+----
 == Configurations
 
 .Docker Configuration Options
@@ -50,7 +77,7 @@ libraries{
 | Field | Description | Default Value | Required
 
 | build_strategy
-| Sets how the library will build the container image(s); Must be dockerfile, docker-compose, or modules
+| Sets how the library will build the container image(s); Must be dockerfile, docker-compose, build, or modules
 | dockerfile
 | false
 
@@ -81,8 +108,46 @@ libraries{
 
 | build_args
 | A block of build arguments to pass to `docker build`. For more information, see below. 
+|
+|
 
+| setExperimentalFlag
+| If the docker version only has buildx as an expermential feature then this allows that flag to be set
+| false 
+| false
 
+| same_repo_different_tags
+| When building multiple images dont change the repo name but append the image name to the tag
+| false
+| false
+
+| buildx[].name
+| the name that is attached to the key of the map of the specific element of the buildx array
+| 
+| true
+
+| buildx[].useLatestTag
+| Add an additional latest tag to the image being built on top of the other tag
+| false
+| false
+
+| buildx[].tag
+| Override the tag with a string
+| git sha from repo
+| false
+
+| buildx[].context
+| Dockerfile context for that image
+| "."
+| false
+
+| buildx[].platforms
+| array of platforms to be built for that image
+| linux/amd64
+| false
+
+| buildx[].build_args
+| A block of build arguments to pass for that element to `docker buildx`. For more information, see below. 
 
 |===
 
@@ -126,6 +191,132 @@ libraries{
 <1> This will result in the build argument `--build-arg GITHUB_TOKEN=<secret text>` being passed to `docker build`. The library will mask the value of the secret from the build log. 
 <2> The type of "credential" must be set. This gives the library flexibilty in the future to support other build argument types
 <3> This credential must exist and be a Secret Text credential in the Jenkins credential store. The library could be extended in the future to support other types of credentials, when necessary. 
+
+== Buildx Configuration
+
+In order to use the buildx step, the build strategy must be set to 'buildx'. 
+
+This step provides covers 3 use cases for building multi-architecture. 
+
+. Single docker image name with one tag. e.g example:1.0
+
+.. Use case where the pipeline can build multiple architectures into a single docker image manifest. 
+.. This method of building the image requires that the base image also supports all the architectures that the pipeline is building for. 
+
+Example Configuration Snippet for buildx Single docker image name with one tag
+
+[source,groovy]
+----
+libraries{
+  docker {
+        build_strategy = "buildx"
+        registry = "docker-registry.default.svc:5000"
+        cred = "docker_creds"
+        repo_path_prefix = "java"
+        buildx {
+            name {
+                build_args {
+                    BASE_IMAGE = "alpine:3.12"
+                }
+                platforms = ["linux/amd64","linux/arm64","linux/arm/v7"]
+                useLatestTag = true          
+            }
+        }
+    }
+}
+----
+
+output buildx command from above: 
+[source,bash]
+----
+
+docker buildx build . -t docker-registry.default.svc:5000/java/example:<insert git sha> -t docker-registry.default.svc:5000/java/example:latest --platform linux/amd64,linux/arm64,linux/arm/v7 --build-arg=BASE_IMAGE=alpine:3.12 --push
+----
+. Single docker image name with multiple tags. e.g example:1.0-amd64 example:1.0-arm64
+
+.. This covers the use case when there is not a multi-architecture base image that can be used to build a single image manifest. 
+.. Buildx is an array of maps that are seperated by unique keys. this allows the pipeline to use the same dockerfile with a parameterized base image or multiple dockerfiles. 
+.. This method requires that the 'same_repo_different_tags' flag is set to true and for each element key in buildx to be unique. 
+.. There can only be one element that can use the useLatestTag as it will throw an error due to the pipeline attempting to overwrite another image being built. 
+
+Example Configuration Snippet for buildx Single docker image name with one tag
+
+[source,groovy]
+----
+libraries{
+  docker {
+        build_strategy = "buildx"
+        registry = "docker-registry.default.svc:5000"
+        cred = "docker_creds"
+        repo_path_prefix = "java"
+        same_repo_different_tags = true
+        buildx {
+            amd64 {
+                build_args {
+                    BASE_IMAGE = "alpine:3.12"
+                }
+                platforms = ["linux/amd64"]
+                useLatestTag = true
+                tag = "1.0"         
+            }
+            arm64 {
+                build_args {
+                    BASE_IMAGE = "alpine:3.12"
+                }
+                platforms = ["linux/arm64"]
+                tag = "1.0"
+            }
+        }
+    }
+}
+----
+output buildx command from above: 
+[source,bash]
+----
+docker buildx build . -t docker-registry.default.svc:5000/java/example:1.0-amd64 -t docker-registry.default.svc:5000/java/example:latest --platform=linux/amd64 --build-arg=BASE_IMAGE=alpine:3.12 --push
+docker buildx build . -t docker-registry.default.svc:5000/java/example:1.0-arm64 --platform=linux/arm64 --build-arg=BASE_IMAGE=alpine:3.12 --push
+----
+
+. Multiple docker image names with multiple tags. e.g example-big:1.0 example-small:1.0
+
+.. This use case where there is a single repo with multiple images that need to be built for multiple architectures. 
+.. each elemement's key must be unique for this to build properly or else it will override previous images. 
+
+Example Configuration Snippet for buildx Single docker image name with one tag
+
+[source,groovy]
+----
+libraries{
+  docker {
+        build_strategy = "buildx"
+        registry = "docker-registry.default.svc:5000"
+        cred = "docker_creds"
+        repo_path_prefix = "java"
+        buildx {
+            jre {
+                build_args {
+                    BASE_IMAGE = "alpine:3.12"
+                }
+                platforms = ["linux/amd64","linux/arm64","linux/arm/v7"]
+                tag = "1.0"         
+            }
+            jdk {
+                build_args {
+                    BASE_IMAGE = "alpine:3.12"
+                }
+                platforms = ["linux/amd64","linux/arm64","linux/arm/v7"]
+                tag = "1.0"
+            }
+        }
+    }
+}
+----
+output buildx commands from above: 
+[source,bash]
+----
+docker buildx build ./jdk -t docker-registry.default.svc:5000/java/example-jdk:1.0 --platform linux/amd64,linux/arm64,linux/arm/v7 --build-arg=BASE_IMAGE=alpine:3.12 --push
+docker buildx build ./jre -t docker-registry.default.svc:5000/java/example-jre:1.0 --platform linux/amd64,linux/arm64,linux/arm/v7 --build-arg=BASE_IMAGE=alpine:3.12 --push
+----
 
 == External Dependencies
 

--- a/docs/modules/ROOT/pages/libraries/docker.adoc
+++ b/docs/modules/ROOT/pages/libraries/docker.adoc
@@ -93,7 +93,7 @@ libraries{
 | false
 
 | same_repo_different_tags
-| When building multiple images dont change the repo name but append the image name to the tag
+| When building multiple images dont change the repo name but append the key name to the tag
 | false
 | false
 

--- a/docs/modules/ROOT/pages/libraries/docker.adoc
+++ b/docs/modules/ROOT/pages/libraries/docker.adoc
@@ -53,7 +53,7 @@ libraries{
 | Field | Description | Default Value | Required
 
 | build_strategy
-| Sets how the library will build the container image(s); Must be dockerfile, docker-compose, build, or modules
+| Sets how the library will build the container image(s); Must be dockerfile, docker-compose, buildx, or modules
 | dockerfile
 | false
 

--- a/libraries/docker/steps/buildx.groovy
+++ b/libraries/docker/steps/buildx.groovy
@@ -25,11 +25,11 @@ void call(){
 
         String experimentalFlag = ""
         if (setExperimentalFlag) {
-          experimentalFlag = "DOCKER_CLI_EXPERIMENTAL=enabled"
+          experimentalFlag = "DOCKER_CLI_EXPERIMENTAL=enabled "
         }
 
         // create the builder and tell it to spin it up in a container
-        sh "${experimentalFlag} docker buildx create --name smartbuilder --driver docker-container --use"
+        sh "${experimentalFlag}docker buildx create --name smartbuilder --driver docker-container --use"
 
         images.each{ img -> 
             echo "building image"
@@ -43,22 +43,22 @@ void call(){
             String latestTag = ""
             // if the latestTag is used then add the additional tag flag
             if(img.useLatestTag ){
-              latestTag = "-t ${img.registry}/${img.repo}:latest"
+              latestTag = " -t ${img.registry}/${img.repo}:latest"
             }
 
             try {
               withCredentials(creds) {
                   //this experimental=enabled variable allows for buildx to be used on the current docker ce version. later versions do not need this flag
                   //when the docker version gets updates in the jenkins agent then this can be changed. 
-                  sh "${experimentalFlag} docker buildx build  ${img.context} -t ${img.registry}/${img.repo}:${img.tag} ${latestTag} ${args} ${platforms} --push"
+                  sh "${experimentalFlag}docker buildx build ${img.context} -t ${img.registry}/${img.repo}:${img.tag}${latestTag} ${args} ${platforms} --push"
               }
             } catch (any) {
                   error "error building and pushing multiarchitecture image"
-                  sh "${experimentalFlag} docker buildx rm smartbuilder"
+                  sh "${experimentalFlag}docker buildx rm smartbuilder"
             }             
         }
         //remove the builder so that it is not left hanging on the node
-        sh "${experimentalFlag} docker buildx rm smartbuilder"
+        sh "${experimentalFlag}docker buildx rm smartbuilder"
       }
     }
   }

--- a/libraries/docker/steps/buildx.groovy
+++ b/libraries/docker/steps/buildx.groovy
@@ -1,0 +1,125 @@
+package libraries.docker.steps
+
+import com.cloudbees.plugins.credentials.CredentialsProvider
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
+import com.cloudbees.plugins.credentials.Credentials
+
+void call(){
+  stage "Building Multiarch Docker Image", {
+
+    // Build Strategy must be set to buildx in order for this method to work
+    if (!(config.build_strategy == "buildx")) {
+      error "build strategy: ${config.build_strategy} is not buildx"
+    }
+
+    // This is so that if jenkins agents are running with a version of docker that only had buildx in the experimental features 
+    // then it will set the experimental flag
+    boolean setExperimentalFlag = config.containsKey("setExperimentalFlag") ? config.setExperimentalFlag : false 
+
+    node{
+      unstash "workspace"
+      
+      login_to_registry{
+        // returns array of images to build
+        ArrayList images = get_images_to_build()
+
+        String experimentalFlag = ""
+        if (setExperimentalFlag) {
+          experimentalFlag = "DOCKER_CLI_EXPERIMENTAL=enabled"
+        }
+
+        // create the builder and tell it to spin it up in a container
+        sh "${experimentalFlag} docker buildx create --name smartbuilder --driver docker-container --use"
+
+        images.each{ img -> 
+            echo "building image"
+            // returns the platforms to build for this image in the format needed for buildx
+            String platforms = getPlatforms(img.platforms)
+            // each image in the array has its own build arguments so get this specific image's arguments
+            def returnedArgs = getBuildArgs(img.build_args)
+            def creds = returnedArgs["creds"]
+            def args = returnedArgs["args"]
+
+            String latestTag = ""
+            // if the latestTag is used then add the additional tag flag
+            if(img.useLatestTag ){
+              latestTag = "-t ${img.registry}/${img.repo}:latest"
+            }
+
+            try {
+              withCredentials(creds) {
+                  //this experimental=enabled variable allows for buildx to be used on the current docker ce version. later versions do not need this flag
+                  //when the docker version gets updates in the jenkins agent then this can be changed. 
+                  sh "${experimentalFlag} docker buildx build  ${img.context} -t ${img.registry}/${img.repo}:${img.tag} ${latestTag} ${args} ${platforms} --push"
+              }
+            } catch (any) {
+                  error "error building and pushing multiarchitecture image"
+                  sh "${experimentalFlag} docker buildx rm smartbuilder"
+            }             
+        }
+        //remove the builder so that it is not left hanging on the node
+        sh "${experimentalFlag} docker buildx rm smartbuilder"
+      }
+    }
+  }
+}
+
+def getBuildArgs(def build_args){
+
+  echo "Getting Build Args"
+
+  ArrayList buildArgs = []
+  def creds = []
+
+  build_args.each{ argument, value ->
+    if(value instanceof Map){
+      switch(value?.type){
+        case "credential": // validate credential exists and is a secrettext cred
+          def allCreds = CredentialsProvider.lookupCredentials(Credentials, Jenkins.get(),null, null)
+          def cred = allCreds.find{ it.id.equals(value.id) }
+          if(cred == null){
+              error "docker library: build argument '${argument}' specified credential id '${value.id}' which does not exist."
+          }
+          if(!(cred instanceof StringCredentialsImpl)){
+            error "docker library: build argument '${argument}' credential must be a Secret Text."
+          }
+          creds << string(credentialsId: value.id, variable: argument)
+          buildArgs << "--build-arg ${argument}=\$${argument}"
+          break;
+        case null: // no build argument type provided
+          error "docker library: build argument '${argument}' must specify a type"
+          break;
+        default: // unrecognized argument type
+          error "docker library: build argument '${argument}' type of '${value.type}' is not recognized"
+      }
+    } else {
+      buildArgs << "--build-arg ${argument}='${value}'"
+    }
+  }
+
+  //due to each image having its own build args and credentials, returning this map is necessary so that each image can set the creds properly
+  def returnList = ["args": buildArgs.join(" "), "creds": creds]
+
+  return returnList
+}
+
+String getPlatforms(def platformsArr) {
+  echo "Getting platforms to build image for"
+
+  String platforms = "--platform"
+
+  // default to amd64 if platforms are not set
+  if(platformsArr.size() == 0){
+    return platforms + " linux/amd64"
+  }
+
+  platformsArr.eachWithIndex { platform, index -> 
+
+    if (index == 0){
+      platforms += " ${platform}"
+    } else {
+          platforms += ",${platform}"
+    }
+  }
+  return platforms
+}

--- a/libraries/docker/steps/get_images_to_build.groovy
+++ b/libraries/docker/steps/get_images_to_build.groovy
@@ -21,7 +21,7 @@ def call(){
     def (image_reg) = get_registry_info() // config.registry
     def path_prefix = config.repo_path_prefix ? config.repo_path_prefix + "/" : ""
 
-    def build_strategies = [ "docker-compose", "modules", "dockerfile" ]
+    def build_strategies = [ "docker-compose", "modules", "dockerfile", "buildx" ]
     if (config.build_strategy)
     if (!(config.build_strategy in build_strategies))
       error "build strategy: ${config.build_strategy} not one of ${build_strategies}"
@@ -42,6 +42,9 @@ def call(){
           ])
         }
         break
+      case "buildx":
+        images = buildx(image_reg,path_prefix)
+        break
       case "dockerfile": //same as null/default case
       case null:
         images.push([
@@ -52,6 +55,82 @@ def call(){
         ])
         break
     }
-
+    
     return images
+}
+
+ArrayList buildx(image_reg, path_prefix) {
+
+  ArrayList images = []
+
+  def buildx = config.buildx ?: { error "buildx not defined in Pipeline Config" } ()
+  def same_repo_different_tags = config.same_repo_different_tags ?: false
+
+  buildx.each{ name,img -> 
+
+    String repo = ""
+    String context = ""
+    String tag = ""
+    boolean useLatestTag = false
+    boolean latestTagUsed = false
+
+    // if the pipeline config does not contain a context to where the dockerfile is then look at root
+    if (!img.containsKey("context")) {
+      context = "."
+    } else {
+      context = img.context
+    }
+    // if a custom tag is to be used then it can be specified. otherwise it will use the git sha
+    if (!img.containsKey("tag")) {
+      tag += env.GIT_SHA
+    } else {
+      tag += img.tag
+    }
+    // if you need a latest tag in addition to the defined tag or the git sha tag
+    if(img.containsKey("useLatestTag")) {
+        // if the pipeline has useLatestTag set to true and is trying to build for the same repo
+        if (img.useLatestTag && same_repo_different_tags) {
+          // check if latest flag has already been used for the repo and if it hasnt then set the latest tag
+          if (!latestTagUsed) {
+            useLatestTag = img.useLatestTag
+            latestTagUsed = true
+          }
+          //else error because it should not override the other image that previously set the latest flag
+          else {
+            error "Cannot use multiple latest tags if you are building multiple images for the same repo"
+          }
+          // if not building with the same repo name or useLatestTag is set to false then use the config value
+        } else {
+          useLatestTag = img.useLatestTag
+        }
+    }
+
+    //if sameNameDifferentTags flag is set then it will keep the repo name the same and appends the element name to the tag
+    if (same_repo_different_tags) {
+      tag += "-" + name
+      repo = "${path_prefix}${env.REPO_NAME}".toLowerCase()
+    }
+    else {
+      // if there is only one element in buildx array than it does not need the name variable from the pipeline config to make the repo unique so it will skip this step
+      // othwise if it is building more than one image, than each image should have a unique name so it appends the element name to the repo
+      if (!(buildx.size() == 1)) {
+          repo = "${path_prefix}${env.REPO_NAME}_${name}".toLowerCase()
+        }else {
+          repo = "${path_prefix}${env.REPO_NAME}".toLowerCase()
+        }      
+    }
+
+    //push the image into the array for the buildx method to use
+    images.push([
+      registry: image_reg,
+      repo: repo,
+      tag: tag,
+      context: context,
+      build_args: img.build_args,
+      platforms: img.platforms,
+      useLatestTag: useLatestTag
+    ])
+  }
+
+  return images
 }

--- a/libraries/docker/steps/get_images_to_build.groovy
+++ b/libraries/docker/steps/get_images_to_build.groovy
@@ -16,7 +16,7 @@ package libraries.docker.steps
   a docker build command would then be:
     docker build img.context -t img.registry/img.repo:img.tag
 
-  in the case of buildx each image in the arra is a hashmap with fields:
+  in the case of buildx each image in the array is a hashmap with fields:
     registry: image registry
     repo: repo name
     tag: image tag

--- a/libraries/docker/steps/get_images_to_build.groovy
+++ b/libraries/docker/steps/get_images_to_build.groovy
@@ -15,6 +15,15 @@ package libraries.docker.steps
 
   a docker build command would then be:
     docker build img.context -t img.registry/img.repo:img.tag
+
+  in the case of buildx each image in the arra is a hashmap with fields:
+    registry: image registry
+    repo: repo name
+    tag: image tag
+    context: context for dockerfile
+    build_args: build args for the specific image
+    platforms: platforms to be built for
+    useLatestTag: if pipeline will use the previously defined tag + the latest tag
 */
 def call(){
 
@@ -55,7 +64,7 @@ def call(){
         ])
         break
     }
-    
+
     return images
 }
 

--- a/test/docker/BuildxSpec.groovy
+++ b/test/docker/BuildxSpec.groovy
@@ -1,0 +1,73 @@
+/*
+  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+
+package libraries.docker
+
+public class BuildxSpec extends JTEPipelineSpecification {
+
+  def Buildx = null
+
+  def setup() {
+    Buildx = loadPipelineScriptForStep("docker", "buildx")
+    explicitlyMockPipelineStep("get_images_to_build")
+    explicitlyMockPipelineStep("login_to_registry")
+    Buildx.getBinding().setVariable("config", [build_strategy: 'buildx'])
+
+    getPipelineMock("get_images_to_build")() >> {
+      def images = []
+      images << [registry: "reg1", repo: "repo1", context: "context1", tag: "tag1", build_args: null, platforms: ["arm", "amd64"], useLatestTag: true]
+      images << [registry: "reg2", repo: "repo2", context: "context2", tag: "tag2", build_args: [BASE_IMAGE:"image"], platforms: ["arm", "amd64"], useLatestTag: false]
+      return images
+    }
+  }
+
+  def "Unstash workspace Before Building Images" () {
+    when:
+      Buildx()
+    then:
+      1 * getPipelineMock("unstash")("workspace")
+    then:
+      (1.._) * getPipelineMock("sh")({it =~ /^docker buildx */})
+  }
+
+  def "Log Into Registry Before Pushing Images" () {
+    when:
+      Buildx()
+    then:
+      1 * getPipelineMock("login_to_registry")(_)
+    then:
+      (1.._) * getPipelineMock("sh")({it =~ /^docker buildx */})
+  }
+
+  def "Each Image is Properly Built and pushed" () {
+    when:
+      Buildx()
+    then:
+      1 * getPipelineMock("sh")("docker buildx build context1 -t reg1/repo1:tag1 -t reg1/repo1:latest  --platform arm,amd64 --push")
+      1 * getPipelineMock("sh")("docker buildx build context2 -t reg2/repo2:tag2 --build-arg BASE_IMAGE='image' --platform arm,amd64 --push")
+  }
+
+  def "If value is true for config.setExperimentalFlag,set the experimental flag" () {
+    setup:
+      Buildx.getBinding().setVariable("config", [setExperimentalFlag: true, build_strategy: 'buildx'])
+    when:
+      Buildx()
+    then:
+      1 * getPipelineMock("sh")("DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name smartbuilder --driver docker-container --use")
+      1 * getPipelineMock("sh")("DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build context1 -t reg1/repo1:tag1 -t reg1/repo1:latest  --platform arm,amd64 --push")
+      1 * getPipelineMock("sh")("DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build context2 -t reg2/repo2:tag2 --build-arg BASE_IMAGE='image' --platform arm,amd64 --push")
+  }
+  def "If value is false for config.setExperimentalFlag,set the experimental flag to false" () {
+    setup:
+      Buildx.getBinding().setVariable("config", [setExperimentalFlag: false, build_strategy: 'buildx'])
+    when:
+      Buildx()
+    then:
+      0 * getPipelineMock("sh")("DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name smartbuilder --driver docker-container --use")
+      0 * getPipelineMock("sh")("DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build context1 -t reg1/repo1:tag1 -t reg1/repo1:latest  --platform arm,amd64 --push")
+      0 * getPipelineMock("sh")("DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build context2 -t reg2/repo2:tag2 --build-arg BASE_IMAGE='image' --platform arm,amd64 --push")
+  }
+
+}


### PR DESCRIPTION
# PR Details

- Added the `buildx` step to the docker library. 
- Modified `get_images_to_build` to include a new build strategy of 'buildx'
- Documentation and unit tests

## Description

1. Added the `buildx` step to the docker library. Docker buildx uses emulation to build multi-architecture images. Using this step you can build multi-architecture images, images for a different architecture than the host, and multiple multi-architecture images in the same repo. In the pipeline_config there is now a buildx parameter that is an array of hashmaps. There are additional parameters that have been added but do not conflict with the original docker steps. See documentation. 

2. Modified `get_images_to_build` to include a new build strategy of 'buildx'. This allows for buildx to not conflict or break any of the other steps in the docker library. It will build an array of images from the buildx array in the pipeline_config

3. Documentation and unit tests. Added additional documentation and unit tests to the docker library to cover the uses of `buildx`. 


## How Has This Been Tested

These changes have been tested using unit tests. All new and existing tests pass. 
These changes have also been tested in a live jenkins environment. I have created around 15 unique pipelines that are all using the buildx step without issue. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I am submitting this pull request to the appropriate branch
- [ x] I have labeled this pull request appropriately
- [ x] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
