### PR TITLE
.NET Sonar Scanner

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -20,6 +20,7 @@
 * xref:libraries/sdp.adoc[SDP]
 * xref:libraries/slack.adoc[Slack]
 * xref:libraries/sonarqube.adoc[SonarQube]
+* xref:libraries/dotnet_sonarqube.adoc[.NET SonarQube]
 * xref:libraries/sysdig_secure.adoc[Sysdig Secure]
 * xref:libraries/terraform.adoc[Terraform]
 * xref:libraries/twistlock.adoc[Twistlock]

--- a/docs/modules/ROOT/pages/libraries/dotnet_sonarqube.adoc
+++ b/docs/modules/ROOT/pages/libraries/dotnet_sonarqube.adoc
@@ -1,0 +1,145 @@
+= SonarQube
+
+SonarQube is a tool used for *static code analysis*. Static code analysis is validating code as-written against industry standard practices.  It will help you find best practice violations and potential security vulnerabilities.
+
+Organizations can define Quality Profiles which are custom rule profiles that projects must use.  Quality Gates are then rules defining the organizational policies for code quality. SDP will, by default, fail the build if the Quality Gate fails.
+
+SonarQube has a specific scanner for .NET applications. See https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-msbuild/[SonarScanner for .NET] for more details.
+
+==  Steps Contributed
+
+.Steps
+|===
+| Step | Description
+
+| ``dotnet_static_code_analysis()``
+| Leverages the dotnet sonar-scanner cli to perform static code analysis and sends results to the configured SonarQube server
+
+|===
+
+== Library Configuration Options
+
+.SonarQube Library Configuration Options
+|===
+| Field | Description | Default Value
+
+| `installation_name`
+| The name of the SonarQube installation configured in `Manage Jenkins > Configure System`
+| "SonarQube"
+
+| `credential_id`
+| The Jenkins credential ID to use when authenticating to SonarQube.  Can either be a valid username/password or an API Token stored in a Secret Text credential type. 
+| If unset, the library will check if the installation defined via `installation_name` has a server authorization token configured.  If a server authorization token has been provided in the plugin configuration, then that will be the default.  If unset, then a credential id of "sonarqube" will be assumed.
+
+| `wait_for_quality_gate`
+| Whether or not to wait for SonarQube to send a webhook back to Jenkins notifying with the Quality Gate result
+| true 
+
+| `enforce_quality_gate`
+| Determine whether the build will fail if the code does not pass the quality gate
+| true
+
+| `stage_display_name`
+| Purely aesthetic.  The name of the stage block during analysis for pipeline visualization in the Jenkins console.
+| "SonarQube Analysis"
+
+| `timeout_duration`
+| The number representing how long to wait for the Quality Gate response before timing out
+| 1
+
+| `timeout_unit`
+| One of [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
+| "HOURS" 
+
+| `cli_parameters`
+| a list of additional CLI analysis parameters to pass the `sonar-scanner` cli.
+| [ ]
+
+| `unstash`
+| a list of pre-existing stashes to try to unstash. Useful if a previous step creates compiled classes or test results for SonarQube to inspect. 
+| [ "TestResults" ] 
+
+
+| `project_key`
+| Project key for the sonarqube project.
+| ${env.ORG_NAME}:${env.REPO_NAME}
+
+
+| `test_output_dir`
+| The directory to store results from tests and code coverage. SonarQube will look at this directory for metrics. 
+| "TestResults" 
+
+
+| `coverage_settings_file`
+| The settings file to define code coverage.
+| "coverage.settings" 
+
+|===
+
+=== Environment Variables
+
+It's possible to use pipeline environment variables to populate the analysis parameters.  This is especially useful when used with one of the source code management libraries to reference the branch name. 
+
+==== Configuration File 
+
+The .NET Sonar Scanner does not use a configuration file. However, we do require a `coverlet.settings` file for code coverage scanning.
+
+coverlet.settings
+[source, xml]
+----
+
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>opencover</Format>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>
+----
+
+==== CLI Parameters 
+
+See https://docs.sonarqube.org/latest/analysis/analysis-parameters/[SonarQube Documentation] for list of CLI parameters.
+
+.pipeline_config.groovy
+[source,groovy]
+----
+libraries{
+    sonarqube{
+        cli_parameters = [ 
+            "/d:sonar.dotnet.excludeTestProjects=true"
+        ]
+    }
+}
+----
+
+==  External Dependencies
+
+* A SonarQube server should be deployed
+* The https://plugins.jenkins.io/sonar/[SonarQube Scanner] plugin should be installed
+* The SonarQube Installation must be configured in `Manage Jenkins > Configure System > SonarQube servers`
+** The "Enable injection of SonarQube server configuration as build environment variables" checkbox should be checked
+
+== Authentication
+
+This library supports both username/password and API Token authentication to SonarQube. 
+
+If anonymous access is disabled for the SonarQube Server (*it probably should be*), then you will need to create an API Token and store it as a Secret Text credential in the Jenkins Credential Store for reference in `Manage Jenkins > Configure System > Sonarqube servers` as the `Server authentication token`.
+
+==  Troubleshooting
+
+==  FAQ
+
+=== What is the difference between this and the sonarqube scanner?
+
+Applications built with .NET are now required to use the .NET Sonar Scanner. This scanner does *not* use the configuration file and must pass in the project key and other CLI arguments directly.
+
+=== How do I set the project key?
+
+If the `project_key` configuration variable is not set, this step will use the repository name as the project key.
+Set the `project_key` configuration variable to change the project key.

--- a/libraries/sonarqube/library_config.groovy
+++ b/libraries/sonarqube/library_config.groovy
@@ -10,5 +10,8 @@ fields{
         timeout_unit = [ "NANOSECONDS", "MICROSECONDS", "MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS" ]
         cli_parameters = List
         unstash = List
+        project_key = String //dotnet specific
+        test_output_dir = String //dotnet specific
+        coverage_settings_file = String //dotnet specific
     }
 }

--- a/libraries/sonarqube/steps/dotnet_static_code_analysis.groovy
+++ b/libraries/sonarqube/steps/dotnet_static_code_analysis.groovy
@@ -1,0 +1,63 @@
+/*
+  Copyright © 2021 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+
+package libraries.sonarqube.steps
+
+def call(){
+
+    // default values for config options
+    LinkedHashMap defaults = [
+        credential_id: "sonarqube",
+        wait_for_quality_gate: true, 
+        enforce_quality_gate: true,
+        installation_name: "SonarQube",
+        timeout_duration: 1,
+        timeout_unit: "HOURS",
+        stage_display_name: "SonarQube Analysis",
+        unstash: [ "TestResults" ],
+        cli_parameters: []
+    ]
+
+    sonarqube.execute(defaults, "dotnet-sonar-scanner", {
+
+        // dotnet sonarscanner does not use properties file. Try to get project key from env
+        String projectKey = config.project_key ?: '';
+        if(projectKey.isEmpty()){
+            if ((env.ORG_NAME ?: '').isEmpty()){
+                projectKey = "${env.REPO_NAME}"
+            } else {
+                projectKey = "${env.ORG_NAME}:${env.REPO_NAME}"
+            }
+        }
+
+        // build out the command to execute
+        ArrayList beginCommand = [ "dotnet sonarscanner begin /k:${projectKey} /n:${env.REPO_NAME} /d:sonar.verbose=true /d:sonar.cs.opencover.reportsPaths='TestResults/**/coverage.opencover.xml' /d:sonar.cs.vstest.reportsPaths='TestResults/*.trx'" ]
+        ArrayList endCommand = [ "dotnet sonarscanner end" ]
+
+        /*
+            if an API token was used, only provide /d:sonar.login
+            if a username/password was used, provide both /d:sonar.login and /d:sonar.password
+            
+            because of how determineCredentialType() works - the env var sq_user will 
+            only be present if a username/password was provided.
+        */
+        if(env.sq_user){
+            beginCommand << "/d:sonar.login='${env.sq_user}' /d:sonar.password='${env.sq_token}'"
+            endCommand << "/d:sonar.login='${env.sq_user}' /d:sonar.password='${env.sq_token}'"
+        } else {
+            beginCommand << "/d:sonar.login='${env.sq_token}'"
+            endCommand << "/d:sonar.login='${env.sq_token}'"
+        }
+
+        // join user provided params
+        beginCommand << (config.cli_parameters ?: defaults.cli_parameters)
+
+        sh beginCommand.flatten().join(" ")
+        sh "dotnet build"
+        sh "rm -drf ${env.WORKSPACE}/TestResults"
+        sh "dotnet test --settings coverlet.runsettings --results-directory ${env.WORKSPACE}/TestResults --logger trx"
+        sh endCommand.flatten().join(" ")
+    })
+}

--- a/libraries/sonarqube/steps/sonarqube.groovy
+++ b/libraries/sonarqube/steps/sonarqube.groovy
@@ -1,0 +1,124 @@
+/*
+  Copyright © 2021 Booz Allen Hamilton. All Rights Reserved.
+  This software package is licensed under the Booz Allen Public License. 
+  The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+*/
+
+package libraries.sonarqube.steps
+
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.Credentials
+import com.cloudbees.plugins.credentials.CredentialsProvider
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
+import hudson.plugins.sonar.SonarGlobalConfiguration
+
+/* Shared Sonarqube code */
+
+def execute(LinkedHashMap defaults, String sdp_image, Closure scan){
+
+    // whether or not to wait for the quality gate 
+    Boolean wait = defaults.wait_for_quality_gate 
+    if(config.containsKey("wait_for_quality_gate")){
+        wait = config.wait_for_quality_gate
+    }
+    // whether or not to enforce the SQ QG
+    Boolean enforce = defaults.enforce_quality_gate 
+    if(config.containsKey("enforce_quality_gate")){
+        enforce = config.enforce_quality_gate
+    }
+
+    // name of installation to use, as configured in Manage Jenkins > Configure System > SonarQube Installations
+    String installation_name = config.installation_name ?: defaults.installation_name
+    validateInstallationExists(installation_name)
+
+    // credential ID for SonarQube Auth
+    String cred_id = config.credential_id ?: fetchCredentialFromInstallation(installation_name) ?: defaults.credential_id
+
+    // purely aesthetic.  the name of the "Stage" for this task. 
+    String stage_display_name = config.stage_display_name ?: defaults.stage_display_name
+
+    // timeout settings
+    def timeout_duration = config.timeout_duration ?: defaults.timeout_duration
+    String timeout_unit = config.timeout_unit ?: defaults.timeout_unit
+
+    ArrayList unstashList = config.unstash ?: defaults.unstash
+
+    stage(stage_display_name){
+        inside_sdp_image sdp_image, {
+            withCredentials(determineCredentialType(cred_id)) {
+                withSonarQubeEnv(installation_name){
+                    // fetch the source code 
+                    unstash "workspace"
+                    
+                    /*
+                      checks for the existence of a stash called "test-results"
+                      which may have been created by previous steps to store results
+                      that sonarqube will consume
+                    */
+                    unstashList.each{ l ->
+                        try{ unstash l }catch(ex){}
+                    }
+                    
+                    /* Run scanner */
+                    scan()
+                }
+                
+                if(wait){
+                    timeout(time: timeout_duration, unit: timeout_unit) {
+                        def qg = waitForQualityGate()
+                        if (qg.status != 'OK' && enforce) {
+                            error "Pipeline aborted due to quality gate failure: ${qg.status}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def determineCredentialType(String cred_id){
+    def allCreds = CredentialsProvider.lookupCredentials(Credentials, Jenkins.get(),null, null)
+    def cred = allCreds.find{ it.id.equals(cred_id) } 
+
+    if(cred == null){
+        error "SonarQube: Credential with id '${cred_id}' does not exist."
+    }
+
+    if(!(cred.getClass() in [UsernamePasswordCredentialsImpl, StringCredentialsImpl])){
+        error """
+        SonarQube: Credential with id '${cred_id}' must be either: 
+          1. a valid username/password for SonarQube
+          2. a secret text credential storing an API Token. 
+        Found credential type: ${cred.getClass()}
+        """.trim().stripIndent(8)
+    }
+
+    if(cred instanceof UsernamePasswordCredentialsImpl){
+        return [ usernamePassword(credentialsId: cred_id, passwordVariable: 'sq_token', usernameVariable: 'sq_user') ]
+    }
+
+    if(cred instanceof StringCredentialsImpl){
+        return [ string(credentialsId: cred_id, variable: 'sq_token') ] 
+    }
+}
+
+void validateInstallationExists(installation_name){
+    boolean exists = SonarGlobalConfiguration.get().getInstallations().find{
+        it.getName() == installation_name
+    } as boolean
+    if(!exists){
+        error "SonarQube: installation '${installation_name}' does not exist"
+    }
+}
+
+/*
+    when not set - this returns an empty string, "" 
+    which evaluates to false when used in an elvis operator. 
+*/
+String fetchCredentialFromInstallation(installation_name){
+    String id = SonarGlobalConfiguration.get().getInstallations().find{
+        it.getName() == installation_name
+    }.getCredentialsId()
+    return id
+}

--- a/libraries/sonarqube/steps/static_code_analysis.groovy
+++ b/libraries/sonarqube/steps/static_code_analysis.groovy
@@ -5,13 +5,6 @@
 
 package libraries.sonarqube.steps
 
-import jenkins.model.Jenkins
-import com.cloudbees.plugins.credentials.Credentials
-import com.cloudbees.plugins.credentials.CredentialsProvider
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
-import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
-import hudson.plugins.sonar.SonarGlobalConfiguration
-
 def call(){
 
     // default values for config options
@@ -27,134 +20,33 @@ def call(){
         cli_parameters: []
     ]
 
-    // whether or not to wait for the quality gate 
-    Boolean wait = defaults.wait_for_quality_gate 
-    if(config.containsKey("wait_for_quality_gate")){
-        wait = config.wait_for_quality_gate
-    }
-    // whether or not to enforce the SQ QG
-    Boolean enforce = defaults.enforce_quality_gate 
-    if(config.containsKey("enforce_quality_gate")){
-        enforce = config.enforce_quality_gate
-    }
+    sonarqube.execute(defaults, "sonar-scanner", {
+        /*
+            creates an empty directory in the event that a value for 
+            sonar.java.binaries needs to be provided when the binaries
+            are not present during sonarqube analysis
+        */
+        sh "mkdir -p empty"
+        
+        // build out the command to execute
+        ArrayList command = [ "sonar-scanner -X" ]
 
-    // name of installation to use, as configured in Manage Jenkins > Configure System > SonarQube Installations
-    String installation_name = config.installation_name ?: defaults.installation_name
-    validateInstallationExists(installation_name)
-
-    // credential ID for SonarQube Auth
-    String cred_id = config.credential_id ?: fetchCredentialFromInstallation(installation_name) ?: defaults.credential_id
-
-    // purely aesthetic.  the name of the "Stage" for this task. 
-    String stage_display_name = config.stage_display_name ?: defaults.stage_display_name
-
-    // timeout settings
-    def timeout_duration = config.timeout_duration ?: defaults.timeout_duration
-    String timeout_unit = config.timeout_unit ?: defaults.timeout_unit
-
-    ArrayList unstashList = config.unstash ?: defaults.unstash
-
-    stage(stage_display_name){
-        inside_sdp_image "sonar-scanner", {
-            withCredentials(determineCredentialType(cred_id)) {
-                withSonarQubeEnv(installation_name){
-                    // fetch the source code 
-                    unstash "workspace"
-                    
-                    /*
-                      checks for the existence of a stash called "test-results"
-                      which may have been created by previous steps to store results
-                      that sonarqube will consume
-                    */
-                    unstashList.each{ ->
-                        try{ unstash it }catch(ex){}
-                    }
-                    
-                    /*
-                        creates an empty directory in the event that a value for 
-                        sonar.java.binaries needs to be provided when the binaries
-                        are not present during sonarqube analysis
-                    */
-                    sh "mkdir -p empty"
-                    
-                    // build out the command to execute
-                    ArrayList command = [ "sonar-scanner -X" ]
-
-                    /*
-                        if an API token was used, only provide -Dsonar.login 
-                        if a username/password was used, provide both -Dsonar.login and -Dsonar.password
-                        
-                        because of how determineCredentialType() works - the env var sq_user will 
-                        only be present if a username/password was provided.
-                    */
-                    if(env.sq_user){
-                        command << "-Dsonar.login='${env.sq_user}' -Dsonar.password='${env.sq_token}'"
-                    } else {
-                        command << "-Dsonar.login='${env.sq_token}'"
-                    }
-
-                    // join user provided params
-                    command << (config.cli_parameters ?: defaults.cli_parameters)
-
-                    sh command.flatten().join(" ")
-
-                }
-                
-                if(wait){
-                    timeout(time: timeout_duration, unit: timeout_unit) {
-                        def qg = waitForQualityGate()
-                        if (qg.status != 'OK' && enforce) {
-                            error "Pipeline aborted due to quality gate failure: ${qg.status}"
-                        }
-                    }
-                }
-            }
+        /*
+            if an API token was used, only provide -Dsonar.login 
+            if a username/password was used, provide both -Dsonar.login and -Dsonar.password
+            
+            because of how determineCredentialType() works - the env var sq_user will 
+            only be present if a username/password was provided.
+        */
+        if(env.sq_user){
+            command << "-Dsonar.login='${env.sq_user}' -Dsonar.password='${env.sq_token}'"
+        } else {
+            command << "-Dsonar.login='${env.sq_token}'"
         }
-    }
-}
 
-def determineCredentialType(String cred_id){
-    def allCreds = CredentialsProvider.lookupCredentials(Credentials, Jenkins.get(),null, null)
-    def cred = allCreds.find{ it.id.equals(cred_id) } 
+        // join user provided params
+        command << (config.cli_parameters ?: defaults.cli_parameters)
 
-    if(cred == null){
-        error "SonarQube: Credential with id '${cred_id}' does not exist."
-    }
-
-    if(!(cred.getClass() in [UsernamePasswordCredentialsImpl, StringCredentialsImpl])){
-        error """
-        SonarQube: Credential with id '${cred_id}' must be either: 
-          1. a valid username/password for SonarQube
-          2. a secret text credential storing an API Token. 
-        Found credential type: ${cred.getClass()}
-        """.trim().stripIndent(8)
-    }
-
-    if(cred instanceof UsernamePasswordCredentialsImpl){
-        return [ usernamePassword(credentialsId: cred_id, passwordVariable: 'sq_token', usernameVariable: 'sq_user') ]
-    }
-
-    if(cred instanceof StringCredentialsImpl){
-        return [ string(credentialsId: cred_id, variable: 'sq_token') ] 
-    }
-}
-
-void validateInstallationExists(installation_name){
-    boolean exists = SonarGlobalConfiguration.get().getInstallations().find{
-        it.getName() == installation_name
-    } as boolean
-    if(!exists){
-        error "SonarQube: installation '${installation_name}' does not exist"
-    }
-}
-
-/*
-    when not set - this returns an empty string, "" 
-    which evaluates to false when used in an elvis operator. 
-*/
-String fetchCredentialFromInstallation(installation_name){
-    String id = SonarGlobalConfiguration.get().getInstallations().find{
-        it.getName() == installation_name
-    }.getCredentialsId()
-    return id
+        sh command.flatten().join(" ")
+    })
 }

--- a/test/sonarqube/DotnetStaticCodeAnalysisSpec.groovy
+++ b/test/sonarqube/DotnetStaticCodeAnalysisSpec.groovy
@@ -1,0 +1,92 @@
+package libraries.sonarqube
+
+public class DotnetStaticCodeAnalysisSpec extends JTEPipelineSpecification {
+
+  def DotnetStaticCodeAnalysis = null
+  def Sonarqube = null
+  
+  def setup() {
+    DotnetStaticCodeAnalysis = loadPipelineScriptForStep("sonarqube", "dotnet_static_code_analysis")
+    Sonarqube = loadPipelineScriptForTest("sonarqube/steps/sonarqube.groovy")
+    Sonarqube = new SonarqubeHelper().setupMocks(Sonarqube)
+    DotnetStaticCodeAnalysis.getBinding().setVariable("sonarqube", Sonarqube)
+
+    explicitlyMockPipelineStep("inside_sdp_image")
+  }
+
+  def "Dotnet Static Code Analysis runs commands with token" () {
+    setup:
+      LinkedHashMap config = [ project_key : "my-project" ]
+      LinkedHashMap env = [ REPO_NAME: "my-repo", WORKSPACE: "my-workspace", sq_token: "my-token" ]
+
+      DotnetStaticCodeAnalysis.getBinding().setVariable("config", config)
+      DotnetStaticCodeAnalysis.getBinding().setVariable("env", env)
+      Sonarqube.getBinding().setVariable("config", config)
+    when:
+      DotnetStaticCodeAnalysis()
+    then:
+      /* .NET Sonar Scanner Commands */
+      1 * getPipelineMock("sh")('dotnet sonarscanner begin /k:my-project /n:my-repo /d:sonar.verbose=true /d:sonar.cs.opencover.reportsPaths=\'TestResults/**/coverage.opencover.xml\' /d:sonar.cs.vstest.reportsPaths=\'TestResults/*.trx\' /d:sonar.login=\'my-token\'')
+      1 * getPipelineMock("sh")("rm -drf my-workspace/TestResults")
+      1 * getPipelineMock("sh")("dotnet build")
+      1 * getPipelineMock("sh")("dotnet test --settings coverlet.runsettings --results-directory my-workspace/TestResults --logger trx")
+      1 * getPipelineMock("sh")('dotnet sonarscanner end /d:sonar.login=\'my-token\'')
+  }
+
+  def "Dotnet Static Code Analysis runs commands with username and pass" () {
+    setup:
+      LinkedHashMap config = [project_key : "my-project" ]
+      LinkedHashMap env = [ REPO_NAME: "my-repo", WORKSPACE: "my-workspace", sq_user: "my-user", sq_token: "my-token" ]
+
+      DotnetStaticCodeAnalysis.getBinding().setVariable("config", config)
+      DotnetStaticCodeAnalysis.getBinding().setVariable("env", env)
+      Sonarqube.getBinding().setVariable("config", config)
+    when:
+      DotnetStaticCodeAnalysis()
+    then:
+      /* .NET Sonar Scanner Commands */
+      1 * getPipelineMock("sh")('dotnet sonarscanner begin /k:my-project /n:my-repo /d:sonar.verbose=true /d:sonar.cs.opencover.reportsPaths=\'TestResults/**/coverage.opencover.xml\' /d:sonar.cs.vstest.reportsPaths=\'TestResults/*.trx\' /d:sonar.login=\'my-user\' /d:sonar.password=\'my-token\'')
+      1 * getPipelineMock("sh")("rm -drf my-workspace/TestResults")
+      1 * getPipelineMock("sh")("dotnet build")
+      1 * getPipelineMock("sh")("dotnet test --settings coverlet.runsettings --results-directory my-workspace/TestResults --logger trx")
+      1 * getPipelineMock("sh")('dotnet sonarscanner end /d:sonar.login=\'my-user\' /d:sonar.password=\'my-token\'')
+  }
+
+  def "Dotnet Static Code Analysis runs commands project key from env repo" () {
+    setup:
+      LinkedHashMap config = []
+      LinkedHashMap env = [ REPO_NAME: "my-repo", WORKSPACE: "my-workspace", sq_token: "my-token" ]
+
+      DotnetStaticCodeAnalysis.getBinding().setVariable("config", config)
+      DotnetStaticCodeAnalysis.getBinding().setVariable("env", env)
+      Sonarqube.getBinding().setVariable("config", config)
+    when:
+      DotnetStaticCodeAnalysis()
+    then:
+      /* .NET Sonar Scanner Commands */
+      1 * getPipelineMock("sh")('dotnet sonarscanner begin /k:my-repo /n:my-repo /d:sonar.verbose=true /d:sonar.cs.opencover.reportsPaths=\'TestResults/**/coverage.opencover.xml\' /d:sonar.cs.vstest.reportsPaths=\'TestResults/*.trx\' /d:sonar.login=\'my-token\'')
+      1 * getPipelineMock("sh")("rm -drf my-workspace/TestResults")
+      1 * getPipelineMock("sh")("dotnet build")
+      1 * getPipelineMock("sh")("dotnet test --settings coverlet.runsettings --results-directory my-workspace/TestResults --logger trx")
+      1 * getPipelineMock("sh")('dotnet sonarscanner end /d:sonar.login=\'my-token\'')
+  }
+
+  def "Dotnet Static Code Analysis runs commands project key from env org and repo" () {
+    setup:
+      LinkedHashMap config = []
+      LinkedHashMap env = [ ORG_NAME: 'my-org', REPO_NAME: "my-repo", WORKSPACE: "my-workspace", sq_token: "my-token" ]
+
+      DotnetStaticCodeAnalysis.getBinding().setVariable("config", config)
+      DotnetStaticCodeAnalysis.getBinding().setVariable("env", env)
+      Sonarqube.getBinding().setVariable("config", config)
+    when:
+      DotnetStaticCodeAnalysis()
+    then:
+      /* .NET Sonar Scanner Commands */
+      1 * getPipelineMock("sh")('dotnet sonarscanner begin /k:my-org:my-repo /n:my-repo /d:sonar.verbose=true /d:sonar.cs.opencover.reportsPaths=\'TestResults/**/coverage.opencover.xml\' /d:sonar.cs.vstest.reportsPaths=\'TestResults/*.trx\' /d:sonar.login=\'my-token\'')
+      1 * getPipelineMock("sh")("rm -drf my-workspace/TestResults")
+      1 * getPipelineMock("sh")("dotnet build")
+      1 * getPipelineMock("sh")("dotnet test --settings coverlet.runsettings --results-directory my-workspace/TestResults --logger trx")
+      1 * getPipelineMock("sh")('dotnet sonarscanner end /d:sonar.login=\'my-token\'')
+  }
+}

--- a/test/sonarqube/SonarHelper.groovy
+++ b/test/sonarqube/SonarHelper.groovy
@@ -1,0 +1,25 @@
+package libraries.sonarqube
+
+public class SonarqubeHelper {
+  
+  Script setupMocks(Script sonarqubeScript) {   
+    /* Mock methods that call SonarGlobalConfiguration */
+    sonarqubeScript.metaClass.validateInstallationExists = { s -> 
+      return true;
+    }
+    sonarqubeScript.metaClass.fetchCredentialFromInstallation = { s ->
+      return "creds";
+    }
+    sonarqubeScript.metaClass.determineCredentialType = { String cred_id ->
+      return [ string(credentialsId: "creds", variable: 'sq_token') ] 
+    }
+    sonarqubeScript.metaClass.determineCredentialType = { String cred_id ->
+      return [ string(credentialsId: "creds", variable: 'sq_token') ] 
+    }
+    sonarqubeScript.metaClass.waitForQualityGate = { ->
+      return LinkedHashMap[status:'OK']
+    }
+
+    return sonarqubeScript
+  }
+}

--- a/test/sonarqube/StaticCodeAnalysisSpec.groovy
+++ b/test/sonarqube/StaticCodeAnalysisSpec.groovy
@@ -1,0 +1,48 @@
+package libraries.sonarqube
+
+public class StaticCodeAnalysis extends JTEPipelineSpecification {
+
+  def StaticCodeAnalysis = null
+  def Sonarqube = null;
+
+  def setup() {
+    StaticCodeAnalysis = loadPipelineScriptForStep("sonarqube", "static_code_analysis")
+    Sonarqube = loadPipelineScriptForTest("sonarqube/steps/sonarqube.groovy")
+    Sonarqube = new SonarqubeHelper().setupMocks(Sonarqube)
+    StaticCodeAnalysis.getBinding().setVariable("sonarqube", Sonarqube)
+
+    explicitlyMockPipelineStep("inside_sdp_image")
+  }
+
+  def "Static Code Analysis runs commands with token" () {
+    setup:
+      def config = new LinkedHashMap();
+      def env = [sq_token: "my-token" ];
+
+      StaticCodeAnalysis.getBinding().setVariable("config", config)
+      StaticCodeAnalysis.getBinding().setVariable("env", env)
+      Sonarqube.getBinding().setVariable("config", config)
+    when:
+      StaticCodeAnalysis()
+    then:
+      /* .Sonar Scanner Commands */
+      1 * getPipelineMock("sh")('mkdir -p empty')
+      1 * getPipelineMock("sh")('sonar-scanner -X -Dsonar.login=\'my-token\'')
+  }
+
+    def "Static Code Analysis runs commands with username and pass" () {
+    setup:
+      def config = new LinkedHashMap();
+      def env = [sq_user: "my-user", sq_token: "my-token" ];
+
+      StaticCodeAnalysis.getBinding().setVariable("config", config)
+      StaticCodeAnalysis.getBinding().setVariable("env", env)
+      Sonarqube.getBinding().setVariable("config", config)
+    when:
+      StaticCodeAnalysis()
+    then:
+      /* .Sonar Scanner Commands */
+      1 * getPipelineMock("sh")('mkdir -p empty')
+      1 * getPipelineMock("sh")('sonar-scanner -X -Dsonar.login=\'my-user\' -Dsonar.password=\'my-token\'')
+    }
+}


### PR DESCRIPTION
# PR Details

Adds the ability to scan .NET solutions using the [.NET Sonar Scanner](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-msbuild/).

## Description

.NET Applications require a separate sonar scanner (linked above). The biggest differences between this and the original scanner is that the .NET scanner does not and can not use a properties file to define configuration (e.g. project-key). All configuration must be passed in via command line, and project-key is required.

Code coverage is reported by [Coverlet](https://github.com/coverlet-coverage/coverlet). Instructions and an example is provided in the documentation.

This step requires the [.NET image](https://github.com/boozallen/sdp-images/pull/33) be available as it has the required tools installed into the global .NET tools directory. The tools required are the sonar scanner, and the coverlet library.

## How Has This Been Tested

Unit tests for both the original sonar scanner and the dotnet sonar scanner have been written to ensure the underlying shell commands are executed correctly.

The dotnet scanner step has been tested as part of a Jenkins pipeline using the aforementioned dotnet image.

There was some light refactoring since the surrounding code to connect to Sonarqube and get the environment variables are the same between this and the original sonar scanner.

## Types of Changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
