### PR TITLE
Make on_change a combination of on_commit and on_merge 

### DIFF
--- a/libraries/git/steps/on_change.groovy
+++ b/libraries/git/steps/on_change.groovy
@@ -6,8 +6,8 @@ package libraries.git.steps
 
 void call(Map args = [:], body){
 
-  // do nothing if not commit or pr
-  if (!(env.GIT_BUILD_CAUSE in ["commit", "pr"]))
+  // do nothing if not commit or merge
+  if (!(env.GIT_BUILD_CAUSE in ["commit", "merge"]))
     return
 
   def branch = env.BRANCH_NAME


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes -->

The SDP docs say `on_change` is "a combination of on_commit and on_merge". This PR makes this true.

## Description

<!--- Describe your changes in detail -->

The code for `on_commit` has the following check:
```groovy
// do nothing if not commit
if (!env.GIT_BUILD_CAUSE.equals("commit")) 
  return
```

The code for `on_merge` has the following check:
```groovy
// do nothing if not merge
if (!env.GIT_BUILD_CAUSE.equals("merge"))
  return
```

`on_pull_request` checks for `"pr"` which makes sense for running pipeline steps for a PR.

`on_change` was checking for `"commit"` or `"pr"`, but this didn't make much sense to me because "change" implies a change has happened, not that is might happen (from an open PR).

It seems much more useful for `on_change` to be a Git Flow helper method triggered from either a normal commit or a merge commit (after a PR is merged).

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested and confirmed that `on_change` is triggered by GitHub Webhooks whenever a normal commit or a merge commit is made to the specified branch(es).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [ ] I have labeled this pull request appropriately
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
