### PR TITLE
Adding configurable image_name to Docker

### DIFF
--- a/libraries/docker/README.md
+++ b/libraries/docker/README.md
@@ -29,6 +29,7 @@ libraries{
     registry = "docker-registry.default.svc:5000"
     cred = "openshift-docker-registry"
     repo_path_prefix = "proj-images"
+    image_name = "my-container-image"
     remove_local_image = true
     build_args{
       GITHUB_TOKEN{
@@ -52,6 +53,7 @@ libraries{
 | registry_protocol | the protocol to prepend to the `registry` when authenticating to the container registry | "https://" | false |
 | cred | Credentials used for the repository where different docker pipeline tools are stored. |  | true |
 | repo_path_prefix | The part of the repository name between the registry name and the last forward-slash | "" | false |
+| image_name | Name of the container image being built | `env.REPO_NAME` | false |
 | remove_local_image | Determines if the pipeline should remove the local image after building or retagging | false | false |
 | build_args | A block of build arguments to pass to `docker build`. For more information, see below. | | false |
 | setExperimentalFlag | If the docker version only has buildx as an experimental feature then this allows that flag to be set | false | false

--- a/libraries/docker/steps/get_images_to_build.groovy
+++ b/libraries/docker/steps/get_images_to_build.groovy
@@ -6,10 +6,10 @@
 package libraries.docker.steps
 
 /*
-  returns an of the images that are built by this pipeline run.
+  returns an array of the images that are built by this pipeline run.
   each image in the array is a hashmap with fields:
     registry: image registry
-    repo: repo name
+    repo: image name with repo path
     tag: image tag
     context: directory context for docker build
 
@@ -40,6 +40,7 @@ def call(){
     }
 
     def images = []
+    def image_name = config.image_name ?: env.REPO_NAME
 
     switch (config.build_strategy) {
       case "docker-compose":
@@ -49,7 +50,7 @@ def call(){
         findFiles(glob: "*/Dockerfile").collect{ it.path.split("/").first() }.each{ service ->
           images.push([
             registry: image_reg,
-            repo: "${path_prefix}${env.REPO_NAME}_${service}".toLowerCase(),
+            repo: "${path_prefix}${image_name}_${service}".toLowerCase(),
             tag: env.GIT_SHA,
             context: service
           ])
@@ -62,7 +63,7 @@ def call(){
       case null:
         images.push([
           registry: image_reg,
-          repo: "${path_prefix}${env.REPO_NAME}".toLowerCase(),
+          repo: "${path_prefix}${image_name}".toLowerCase(),
           tag: env.GIT_SHA,
           context: "."
         ])

--- a/libraries/docker/test/GetImagesToBuildSpec.groovy
+++ b/libraries/docker/test/GetImagesToBuildSpec.groovy
@@ -59,6 +59,21 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
       "modules"      | "service"     | "test_prefix/git_repo_service"
   }
 
+  def "image_name Properly Overrides env.REPO_NAME When Set" () {
+    setup:
+      GetImagesToBuild.getBinding().setVariable("config", [repo_path_prefix: "test_prefix", build_strategy: build_strategy, image_name: "my-cool-image-name"])
+      GetImagesToBuild.getBinding().setVariable("env", [REPO_NAME: "git_repo", GIT_SHA: "8675309"])
+      getPipelineMock("findFiles")([glob: "*/Dockerfile"]) >> [[path: "service/Dockerfile"]]
+    when:
+      def imageList = GetImagesToBuild()
+    then:
+      imageList == [[registry: "test_registry", repo: repo, context: build_context, tag: "8675309"]]
+    where:
+      build_strategy | build_context | repo
+      "dockerfile"   | "."           | "test_prefix/my-cool-image-name"
+      "modules"      | "service"     | "test_prefix/my-cool-image-name_service"
+  }
+
   def "Invalid build_strategy Throws Error" () {
     setup:
       GetImagesToBuild.getBinding().setVariable("config", [build_strategy: x])


### PR DESCRIPTION
# PR Details

Closes #84 

## Description

Adding `image_name` to Docker library parameters (will continue to default to `env.REPO_NAME`)

## How Has This Been Tested

Added new test to `GetImagesToBuildSpec.groovy` (`image_name Properly Overrides env.REPO_NAME When Set`) and ran all tests locally

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
