### PR TITLE
[Documentation]: updating docs theme and applying new theme features

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,3 +4,5 @@ Vocab = SDP
 BasedOnStyles = Microsoft, Vale
 # ignores tabbed content from pymdownx.tabbed
 BlockIgnores = (?s) *(=== *("|').*("|')( *|)\n( *|)\x60\x60\x60([^\x60]*|\n*)?\x60\x60\x60)
+# ignores faq code admonitions
+TokenIgnores = (\?\?\?\+?\sfaq)

--- a/docs/concepts/unit-testing/faq.md
+++ b/docs/concepts/unit-testing/faq.md
@@ -1,45 +1,49 @@
 # Frequently Asked Questions
 
-This section covers questions that aren't answered in the Spock or Jenkins-Spock documentation.
+*This section covers questions that aren't answered in the Spock or Jenkins-Spock documentation.*
 
-**Q: What's the difference between explicitlyMockPipelineStep and explicitlyMockPipelineVariable?**
-**A: Practically speaking, the difference is you can omit ".call" for explicitlyMockPipelineStep() when you use getPipelineMock()**
+???+ faq "What's the difference between explicitlyMockPipelineStep and explicitlyMockPipelineVariable?"
 
-In the example on the [Writing Tests](./writing-tests.md) page, ``explicitlyMockPipelineStep()`` is used to mock `error`.
-In this case, `1 * getPipelineMock("error")` can be used to see if the `error` pipeline step is run.
-If `explicitlyMockPipelineVariable()` had been used instead, `1 * getPipelineMock("error.call")` could be used to check for the `error` pipeline step.
+    **Practically speaking, the difference is you can omit ".call" for explicitlyMockPipelineStep() when you use getPipelineMock()**
 
-There may be some additional differences as well, so try to use what makes the most sense.
+    In the example on the [Writing Tests](./writing-tests.md) page, ``explicitlyMockPipelineStep()`` is used to mock `error`.
+    In this case, `1 * getPipelineMock("error")` can be used to see if the `error` pipeline step is run.
+    If `explicitlyMockPipelineVariable()` had been used instead, `1 * getPipelineMock("error.call")` could be used to check for the `error` pipeline step.
 
-**Q: What if the exact parameters are unknown?**
-**A: There are ways to match parameters to regex expressions, as well as test parameters individually**
+    There may be some additional differences as well, so try to use what makes the most sense.
 
-The standard format for interaction-based tests is:
+???+ faq "What if the exact parameters are unknown?"
 
-```groovy
-<count> * getPipelineMock(<method>)(<parameter(s)>)
-```
+    **There are ways to match parameters to regex expressions, as well as test parameters individually**
 
-While you can put the exact parameter value in the second parentheses, you can also run arbitrary groovy code inside curly brackets.
-If it's a "match" depends on if that code returns `true` or `false`.
-A good example is in [PenetrationTestSpec.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/owasp_zap/test/PenetrationTestSpec.groovy#L33). Use `it` to get the value of the parameter:
-`1 * getPipelineMock("sh")({it =~ / (zap-cli open-url) Kirk (.+)/})`.
+    The standard format for interaction-based tests is:
 
-**Q: Is interaction-based testing required?**
-**A: No, but you can't get variables the same way as traditional Spock tests**
+    ```groovy
+    <count> * getPipelineMock(<method>)(<parameter(s)>)
+    ```
 
-This is because the script gets run within the `loadPipelineScriptForTest` object.
-You can only access the limited set of variables stored in the binding.
-It makes more sense to see how variables are being used in pipeline steps,
-and make sure those pipeline steps use the correct value for those variables.
+    While you can put the exact parameter value in the second parentheses, you can also run arbitrary groovy code inside curly brackets.
+    If it's a "match" depends on if that code returns `true` or `false`.
+    A good example is in [PenetrationTestSpec.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/owasp_zap/test/PenetrationTestSpec.groovy#L33). Use `it` to get the value of the parameter:
+    `1 * getPipelineMock("sh")({it =~ / (zap-cli open-url) Kirk (.+)/})`.
 
-Similarly, if you need to control how a variable is set,
-you need to stub whatever method or pipeline step sets the initial value for that variable.
+???+ faq "Is interaction-based testing required?"
 
-As an example, in [PenetrationTestSpec.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/owasp_zap/test/PenetrationTestSpec.groovy),
-the `target` variable in [penetration_test.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/owasp_zap/steps/penetration_test.groovy) is tested by checking the parameters to an `sh` step.
+    **No, but you can't get variables the same way as traditional Spock tests**
 
-**Q: What troubleshooting steps are required for "can't run method foo() on null" errors?"**
-**A: You need to find a way to stub the method that sets the value for the object that calls foo()**
+    This is because the script gets run within the `loadPipelineScriptForTest` object.
+    You can only access the limited set of variables stored in the binding.
+    It makes more sense to see how variables are being used in pipeline steps,
+    and make sure those pipeline steps use the correct value for those variables.
 
-Check out an example in [GetImagesToBuildSpec.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/docker/test/GetImagesToBuildSpec.groovy).
+    Similarly, if you need to control how a variable is set,
+    you need to stub whatever method or pipeline step sets the initial value for that variable.
+
+    As an example, in [PenetrationTestSpec.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/owasp_zap/test/PenetrationTestSpec.groovy),
+    the `target` variable in [penetration_test.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/owasp_zap/steps/penetration_test.groovy) is tested by checking the parameters to an `sh` step.
+
+???+ faq "What troubleshooting steps are required for 'can't run method foo() on null' errors?"
+
+    **You need to find a way to stub the method that sets the value for the object that calls foo()**
+
+    Check out an example in [GetImagesToBuildSpec.groovy](https://github.com/boozallen/sdp-libraries/blob/main/libraries/docker/test/GetImagesToBuildSpec.groovy).

--- a/libraries/git/README.md
+++ b/libraries/git/README.md
@@ -18,13 +18,15 @@ libraries{
     github
     github_enterprise
     gitlab{
-      connection (optional) = String // for gitlab_status
+      connection (optional) = String // (1)
       job_name (optional) = String
-      job_status (optional) =  "pending" or "running" or "canceled" or "failed" or "success".
+      job_status (optional) =  ["pending", "running", "canceled", "failed", "success"]
     }
   }
 }
 ```
+
+1. Used for `gitlab_status()`
 
 ## Pipeline Template Business Logic
 

--- a/libraries/kubernetes/README.md
+++ b/libraries/kubernetes/README.md
@@ -169,10 +169,12 @@ libraries{
     helm_configuration_repository_credential = "github"
     k8s_credential = "cluster1-config"
     k8s_context = "staging"
-    promote_previous_image = true // note: making this setting true is redundant, since true is the default
+    promote_previous_image = true // (1)
   }
 }
 ```
+
+1. note: making this setting true is redundant, since true is the default
 
 ### Putting It All Together
 

--- a/libraries/npm/README.md
+++ b/libraries/npm/README.md
@@ -40,8 +40,7 @@ Environment variables and secrets with the same key are set to the definition co
 
 Each available method has config options that can be specified in the application environment or within the library configuration.
 
-``` groovy
-//pipeline_configuration.groovy
+``` groovy title="pipeline_configuration.groovy"
 application_environments{
   dev
   prod{
@@ -52,7 +51,7 @@ application_environments{
         npm_install = "ci"
         env{
           someKey = "prodValue for tests"
-          // more envVars as needed
+          // (1)
           secrets{
             someTextCredential{
               type = "text"
@@ -65,7 +64,7 @@ application_environments{
               passwordVar = "PASS"
               id = "prod-credential-id"
             }
-            // more secrets as needed
+            // (2)
           }
         }
       }
@@ -73,7 +72,7 @@ application_environments{
         script = "prod-build"
         env{
           someKey = "prodValue for builds"
-          // more envVars as needed
+          // (3)
           secrets{
             someTextCredential{
               type = "text"
@@ -86,7 +85,7 @@ application_environments{
               passwordVar = "PASS"
               id = "prod-credential-id"
             }
-            // more secrets as needed
+            // (4)
           }
         }
       }
@@ -102,7 +101,7 @@ libraries{
       npm_install = "install"
       env{
         someKey = "someValue for tests"
-        // more envVars as needed
+        // (5)
         secrets{
           someTextCredential{
             type = "text"
@@ -115,7 +114,7 @@ libraries{
             passwordVar = "PASS"
             id = "some-credential-id"
           }
-          // more secrets as needed
+          // (6)
         }
       }
     }
@@ -124,7 +123,7 @@ libraries{
       npm_install = "skip"
       env{
         someKey = "someValue for builds"
-        // more envVars as needed
+        // (7)
         secrets{
           someTextCredential{
             type = "text"
@@ -137,13 +136,22 @@ libraries{
             passwordVar = "PASS"
             id = "some-credential-id"
           }
-          // more secrets as needed
+          // (8)
         }
       }
     }
   }
 }
 ```
+
+1. more envVars as needed
+2. more secrets as needed
+3. more envVars as needed
+4. more secrets as needed
+5. more envVars as needed
+6. more secrets as needed
+7. more envVars as needed
+8. more secrets as needed
 
 This example shows the prod Application Environment overriding configs set in the library config.
 `npm_build.npm_install` is preserved as set in library config, since it isn't overridden by the Application Environment.

--- a/libraries/openshift/README.md
+++ b/libraries/openshift/README.md
@@ -186,10 +186,12 @@ libraries{
     helm_configuration_repository_credential = "github"
     tiller_namespace = "rhs-tiller"
     tiller_credential = "rhs-tiller"
-    promote_previous_image = true // note: making this setting true is redundant, since true is the default
+    promote_previous_image = true // (1)
   }
 }
 ```
+
+1. note: making this setting true is redundant, since true is the default
 
 ### Putting It All Together
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ theme:
     - navigation.tabs
     - navigation.sections
     - navigation.top
+    - content.code.annotate
   logo: assets/images/jte.svg
   favicon: assets/images/jte.svg
   ## this is a hack
@@ -40,10 +41,12 @@ extra:
 
 markdown_extensions:
   - admonition
+  - pymdownx.details
   - abbr
   - footnotes
   - attr_list
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.highlight
   - pymdownx.superfences
   - toc:

--- a/resources/docs/Dockerfile
+++ b/resources/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:7.3.3
+FROM squidfunk/mkdocs-material:8.0.4
 RUN pip install \
     mkdocs-gen-files \
     mike \


### PR DESCRIPTION
# PR Details

Updating [docs theme](https://github.com/squidfunk/mkdocs-material/) to latest.

## Description

* Updated container image used for docs to latest: [8.0.4](https://hub.docker.com/layers/squidfunk/mkdocs-material/8.0.4/images/sha256-25cd187896afa72c61f7a35e0225cef8a7dca2241070564b86d89d5b734c27c7?context=explore)
* Swapped out manual footnotes in code blocks with new [code annotations](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#adding-annotations)
* Updated FAQs page to use [collapsible code admonition blocks](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#removing-the-title)

## How Has This Been Tested

Locally using `just lint-docs` and `just serve` to review

## Types of Changes

- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
