### PR TITLE
fixing typo in example config snippet

### DIFF
--- a/libraries/owasp_dep_check/README.md
+++ b/libraries/owasp_dep_check/README.md
@@ -37,7 +37,7 @@ OWASP Dependency Check Library Configuration Options
 ```groovy
 libraries{
   owasp_dep_check {
-    scan_target = [ "src" ]
+    scan = [ "src" ]
     cvss_threshold = 9 
   }
 }


### PR DESCRIPTION
# PR Details

Fixing incorrect example config

## Description

`scan_target` should be `scan`

## How Has This Been Tested

N/A

## Types of Changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
