### PR TITLE
fixing Maven required field check

### DIFF
--- a/libraries/maven/steps/maven_invoke.groovy
+++ b/libraries/maven/steps/maven_invoke.groovy
@@ -107,10 +107,10 @@ void setEnvVars(libStepConfig, appStepConfig) {
     }
 
     // Checking to make sure required fields are present (may be redundant once a library_config.groovy is added)
-    ArrayList requiredFields = ['stageName', 'buildContainer', 'phases']
+    ArrayList requiredFields = ['stageName', 'buildContainer']
     String missingRequired = ''
     requiredFields.each { field ->
-        if (!env.containsKey(field)) {
+        if (!envVars.containsKey(field)) {
             missingRequired += "Missing required configuration option: ${field} for step: ${stepContext.name}\n"
         }
     }


### PR DESCRIPTION
# PR Details

Fixing broken required field check.

## Description

`containsKey` check not working on `env` array directly--moving to checking combined configs (`envVars`) array instead.

## How Has This Been Tested

Locally

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
