### PR TITLE
fixing Maven config array handling

### DIFF
--- a/libraries/maven/steps/maven_invoke.groovy
+++ b/libraries/maven/steps/maven_invoke.groovy
@@ -12,6 +12,22 @@ void call(app_env = [:]) {
     LinkedHashMap libStepConfig = config?."${stepContext.name}" ?: [:]
     LinkedHashMap appStepConfig = app_env?.maven?."${stepContext.name}" ?: [:]
 
+    def options = appStepConfig?.options ?:
+                  libStepConfig?.options ?:
+                  [] as String[]
+
+    def goals = appStepConfig?.goals ?:
+                libStepConfig?.goals ?:
+                [] as String[]
+
+    def phases = appStepConfig?.phases ?:
+                 libStepConfig?.phases ?:
+                 [] as String[]
+
+    def artifacts = appStepConfig?.artifacts ?:
+                    libStepConfig?.artifacts ?:
+                    [] as String[]
+
     // Gather and set non-secret environment variables
     this.setEnvVars(libStepConfig, appStepConfig)
 
@@ -21,15 +37,13 @@ void call(app_env = [:]) {
 
         // run maven command in specified container
         withCredentials(creds) {
-            inside_sdp_image "${env['buildContainer']}", {
+            inside_sdp_image "${env.buildContainer}", {
                 unstash 'workspace'
 
                 String command = 'mvn '
-                ['options', 'goals', 'phases'].each { field ->
-                    if (env["${field}"]) {
-                        env["${field}"].each { value -> command += "${value} " }
-                    }
-                }
+                options.each { value -> command += "${value} " }
+                goals.each { value -> command += "${value} " }
+                phases.each { value -> command += "${value} " }
 
                 try {
                     sh command
@@ -38,10 +52,8 @@ void call(app_env = [:]) {
                     throw any
                 }
                 finally {
-                    if (env.containsKey('artifacts')) {
-                        env['artifacts'].each { artifact ->
-                            archiveArtifacts artifacts: artifact, allowEmptyArchive: true
-                        }
+                    artifacts.each { artifact ->
+                        archiveArtifacts artifacts: artifact, allowEmptyArchive: true
                     }
                 }
             }


### PR DESCRIPTION
# PR Details

Fixing broken Maven config array handling

## Description

Attempting to use `env` for array library config variables doesn't work--replacing with internal step arrays

## How Has This Been Tested

In a local environment

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
