### PR TITLE
fixing Syft library file path issue

### DIFF
--- a/libraries/syft/steps/generate_sbom.groovy
+++ b/libraries/syft/steps/generate_sbom.groovy
@@ -16,7 +16,8 @@ void call() {
 
         images.each { img ->
             // pull and save images as tarballs
-            sh "docker save ${img.registry}/${img.repo}:${img.tag} > ${img.registry}-${img.repo}-${img.tag}.tar"
+            String archive_name = "${img.registry}-${img.repo}-${img.tag}.tar".replaceAll("/","-")
+            sh "docker save ${img.registry}/${img.repo}:${img.tag} > ${archive_name}"
         }
 
         stage('Generate SBOM using Syft') {
@@ -24,7 +25,8 @@ void call() {
                 unstash "workspace"
                 images.each { img ->
                     // perform the syft scan
-                    sh "syft ${img.registry}-${img.repo}-${img.tag}.tar -o json=${img.repo}-${img.tag}-${raw_results_file}"
+                    String archive_name = "${img.registry}-${img.repo}-${img.tag}.tar".replaceAll("/","-")
+                    sh "syft ${archive_name} -o json=${img.repo}-${img.tag}-${raw_results_file}"
 
                     // archive the results
                     archiveArtifacts artifacts: "${img.repo}-${img.tag}-${raw_results_file}"

--- a/libraries/syft/test/GenerateSBOMSpec.groovy
+++ b/libraries/syft/test/GenerateSBOMSpec.groovy
@@ -29,8 +29,8 @@ public class GenerateSBOMSpec extends JTEPipelineSpecification {
     when:
       GenerateSBOM()
     then:
-      1 * getPipelineMock('sh').call('syft ghcr.io/boozallen/sdp-images-syft-latest.tar -o json=syft-latest-syft-sbom-results.json')
-      1 * getPipelineMock('sh').call('syft ghcr.io/boozallen/sdp-images-grype-latest.tar -o json=grype-latest-syft-sbom-results.json')
+      1 * getPipelineMock('sh').call('syft ghcr.io-boozallen-sdp-images-syft-latest.tar -o json=syft-latest-syft-sbom-results.json')
+      1 * getPipelineMock('sh').call('syft ghcr.io-boozallen-sdp-images-grype-latest.tar -o json=grype-latest-syft-sbom-results.json')
   }
 
   def "Archives SBOM file as expected" () {


### PR DESCRIPTION
# PR Details

Address file path issue when generating SBOMs using the Syft library for containers in repositories with multi-tiered directory structures.

## Description

Updated filenames used for container tarballs to replace `/` with `-` to keep all archives at the top level and avoid directory permission/availability issues.

## How Has This Been Tested

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
