### PR TITLE
Add "none"  option to disable fail on severity for Grype scans

### DIFF
--- a/libraries/grype/README.md
+++ b/libraries/grype/README.md
@@ -18,7 +18,7 @@ Uses the [Grype CLI](https://github.com/anchore/grype) to scan container images 
 |-----------------------|----------------------------------------------------------|--------|---------------|---------------------------------------------------|
 | `grype_container`     | The container image to execute the scan within           | String | grype:0.38.0  |                                                   |
 | `report_format`       | The output format of the generated report                | String | json          | `json`, `table`, `cyclonedx`, `template`          |
-| `fail_on_severity`    | The severity level threshold that will fail the pipeline | String | high          | `negligible`, `low`, `medium`, `high`, `critical` |
+| `fail_on_severity`    | The severity level threshold that will fail the pipeline | String | high          | `none`, `negligible`, `low`, `medium`, `high`, `critical` |
 | `grype_config`        | A custom path to a grype configuration file              | String | `null`        |                                                   |
 
 ## Grype Configuration File

--- a/libraries/grype/library_config.groovy
+++ b/libraries/grype/library_config.groovy
@@ -2,7 +2,7 @@ fields{
     optional{
         grype_container = String
         report_format = ["json", "table", "cyclonedx", "template"]
-        fail_on_severity = ["negligible", "low", "medium", "high", "critical"]
+        fail_on_severity = ["none", "negligible", "low", "medium", "high", "critical"]
         grype_config = String
     }
 }

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -25,7 +25,7 @@ void call() {
             }
         }
 
-        if (severityThreshold != null) {
+        if (severityThreshold != "none") {
             ARGS += "--fail-on ${severityThreshold} "
         }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes -->
Adds "None" severity.
## Description
The "None" severity allows CVE severity checking to be turned off.
<!--- Describe your changes in detail -->

## How Has This Been Tested
In BASS pipeline
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
