### PR TITLE
Grype SBOM scan capability

### DIFF
--- a/libraries/grype/README.md
+++ b/libraries/grype/README.md
@@ -38,7 +38,7 @@ libraries {
 
 If `grype_config` isn't provided, the default locations for an application are `.grype.yaml`, `.grype/config.yaml`.
 
-!!! note "Learn More About Grype Configuration"
+**NOTE:** Learn More About Grype Configuration
 
    Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
 

--- a/libraries/grype/README.md
+++ b/libraries/grype/README.md
@@ -40,7 +40,7 @@ If `grype_config` isn't provided, the default locations for an application are `
 
 !!! note "Learn More About Grype Configuration"
 
-    Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
+```   Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
 
 ## Dependencies
 

--- a/libraries/grype/README.md
+++ b/libraries/grype/README.md
@@ -38,9 +38,8 @@ libraries {
 
 If `grype_config` isn't provided, the default locations for an application are `.grype.yaml`, `.grype/config.yaml`.
 
-**NOTE:** Learn More About Grype Configuration
 
-   Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
+Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
 
 ## Dependencies
 

--- a/libraries/grype/README.md
+++ b/libraries/grype/README.md
@@ -40,7 +40,7 @@ If `grype_config` isn't provided, the default locations for an application are `
 
 !!! note "Learn More About Grype Configuration"
 
-```   Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
+   Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
 
 ## Dependencies
 

--- a/libraries/grype/resources/transform-grype-scan-results.sh
+++ b/libraries/grype/resources/transform-grype-scan-results.sh
@@ -36,7 +36,7 @@ cat "$RAW_RESULTS" \
 # get the CVE count
 CVE_COUNT=$(cat transformed-results.json | jq -r 'length')
 
-if [ "$CVE_COUNT" -eq 0 ]
+if [ "$CVE_COUNT" -eq "0" ]
 then
   echo "No CVEs detected! :)"
 else

--- a/libraries/grype/resources/transform-grype-scan-results.sh
+++ b/libraries/grype/resources/transform-grype-scan-results.sh
@@ -18,6 +18,7 @@ cat "$RAW_RESULTS" \
         "Medium": 2,
         "Low": 3,
         "None": 4,
+        "Unknown": 4,
       }[.];
 
     .matches

--- a/libraries/grype/resources/transform-grype-scan-results.sh
+++ b/libraries/grype/resources/transform-grype-scan-results.sh
@@ -18,7 +18,6 @@ cat "$RAW_RESULTS" \
         "Medium": 2,
         "Low": 3,
         "None": 4,
-        "Unknown": 4,
       }[.];
 
     .matches
@@ -37,7 +36,7 @@ cat "$RAW_RESULTS" \
 # get the CVE count
 CVE_COUNT=$(cat transformed-results.json | jq -r 'length')
 
-if [ "$CVE_COUNT" -eq "0" ]
+if [ "$CVE_COUNT" -eq 0 ]
 then
   echo "No CVEs detected! :)"
 else

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -77,9 +77,6 @@ void call() {
                                 syftSbom = findFiles(glob: "${reportBase}-*-spdx*")
                             }
                         }
-                        println(syftSbom.size())
-                        syftSbom.each { file ->
-                        println(file.name)}
                     }
                     // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
                     String rawResultsFile, transformedResultsFile
@@ -95,7 +92,7 @@ void call() {
 
                     // perform the grype scan
                     try {
-                        if (scanSbom) {
+                        if (scanSbom && syftSbom) {
                             echo "Scanning provided SBOM artifact"
                             sh "grype sbom:${syftSbom[0]} ${ARGS} >> ${rawResultsFile}"
                         }

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -11,7 +11,11 @@ void call() {
         String ARGS = ""
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
-
+        //test
+        baseDir.eachFileMatch FILES, ~*json.json/, { names << it.name } 
+        names.each { name ->
+        println(name)}
+        //end
         if (outputFormat != null) {
             ARGS += "-o ${outputFormat} "
             if (outputFormat == 'json') {

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -36,6 +36,7 @@ void call() {
                 if (scanSbom) {
                     def syftJsonSbom = findFiles(glob: '*json.json', excludes: '*spdx-json.json')
                     ARGS += "sbom:"
+                    println(syftJsonSbom.size())
                     syftJsonSbom.each { file ->
                     println(file.name)}
 

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -94,11 +94,11 @@ void call() {
                     try {
                         if (scanSbom && syftSbom) {
                             echo "Scanning provided SBOM artifact"
-                            sh "grype sbom:${syftSbom[0]} ${ARGS} >> ${rawResultsFile}"
+                            sh "grype sbom:${syftSbom[0]} ${ARGS} > ${rawResultsFile}"
                         }
                         else {
                             echo "An SBOM artifact was not provided. Scanning registry image."
-                            sh "grype ${img.registry}/${img.repo}:${img.tag} ${ARGS} >> ${rawResultsFile}"
+                            sh "grype ${img.registry}/${img.repo}:${img.tag} ${ARGS} > ${rawResultsFile}"
                         }
                     }
                     // Catch the error on quality gate failure

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -13,7 +13,7 @@ void call() {
         Boolean shouldFail = false 
 
         if (scanSbom) {
-            def files = findFiles(glob: './*json.json')
+            def files = findFiles(glob: '**/*json.json')
             ARGS += "sbom:"
             files.each { file ->
             println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -68,7 +68,7 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     if (scanSbom) {
-                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json")
+                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json").replaceAll("/","-")
                         println(syftJsonSbom.size())
                         syftJsonSbom.each { file ->
                         println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -70,8 +70,8 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        def files = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json") echo """${files[0].name} ${files[0].path} ${files[0].directory} ${files[0].length} ${files[0].lastModified}"""
-                        println(files)
+                        def files = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json") 
+                        echo """${files[0].name} ${files[0].path} ${files[0].directory} ${files[0].length} ${files[0].lastModified}"""
                         
                         }
 

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -68,9 +68,8 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     if (scanSbom) {
-                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json")
-                        println(img.repo)
-                        println(img.tag)
+                        String reportBase = "${img.repo}"-"${img.tag}".replaceAll("/","-")
+                        def syftJsonSbom = findFiles(glob: "${reportBase}-*-json.json")
                         println(syftJsonSbom.size())
                         syftJsonSbom.each { file ->
                         println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -6,11 +6,14 @@ void call() {
         String outputFormat = config?.report_format ?: 'json'
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
+        Boolean scanSbom = config?.scan_sbom :? false
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
-
+        //test
+        println(config.syft.raw_results_file)
+        //end
         if (outputFormat != null) {
             ARGS += "-o ${outputFormat} "
             if (outputFormat == 'json') {
@@ -112,4 +115,9 @@ void call() {
             }
         }
     }
+}
+
+void findSbom() {
+    def sbomPattern = ~'json|cyclonedx|json'
+
 }

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -11,14 +11,14 @@ void call() {
         String ARGS = ""
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
-        //test
-        def baseDir = new File('.')
-        baseDir.traverse { File file ->
-        if(file.name.endsWith('.json')) {
-            println file.name
+
+        if (scan_sbom) {
+            def files = findFiles(glob: '*json.json')
+            ARGS += "sbom:"
+            files.each { file ->
+            println(file.name)}
+            
         }
-        }
-        //end
         if (outputFormat != null) {
             ARGS += "-o ${outputFormat} "
             if (outputFormat == 'json') {

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,12 +7,13 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.grype.scan_sbom ?: false
+        String baseDir = "./"
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
         //test
-        baseDir.eachFileMatch FILES, ~*json.json/, { names << it.name } 
+        baseDir.eachFileMatch FILES, ~/\*json.json/, { names << it.name } 
         names.each { name ->
         println(name)}
         //end

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -96,9 +96,11 @@ void call() {
                     // perform the grype scan
                     try {
                         if (scanSbom) {
+                            echo "Scanning provided SBOM artifact"
                             sh "grype sbom:${syftSbom[0]} ${ARGS} >> ${rawResultsFile}"
                         }
                         else {
+                            echo "An SBOM artifact was not provided. Scanning registry image."
                             sh "grype ${img.registry}/${img.repo}:${img.tag} ${ARGS} >> ${rawResultsFile}"
                         }
                     }

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -34,7 +34,7 @@ void call() {
             login_to_registry{
                 unstash "workspace"
                 if (scanSbom) {
-                    def syftJsonSbom = findFiles(glob: '*json.json')
+                    def syftJsonSbom = findFiles(glob: '*json.json', excludes: '*spdx-json.json')
                     ARGS += "sbom:"
                     syftJsonSbom.each { file ->
                     println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -13,7 +13,7 @@ void call() {
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
         //test
-        baseDir.eachFileMatch FILES, ~/\*json.json/, { names << it.name } 
+        baseDir.eachFileMatch FileType.any, ~/\*json.json/, { names << it.name } 
         names.each { name ->
         println(name)}
         //end

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -6,7 +6,7 @@ void call() {
         String outputFormat = config?.report_format ?: 'json'
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
-        Boolean scanSbom = config?.grype.scan_sbom ?: false
+        Boolean scanSbom = config?.scan_sbom ?: false
         String baseDir = "./"
         String resultsFileFormat = ".txt"
         String ARGS = ""

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -69,6 +69,7 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     if (scanSbom) {
+                        String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").each { file ->
                         println(file)}
                         //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -70,10 +70,8 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        def files = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json") 
-                        echo """${files[0].name} ${files[0].path} ${files[0].directory} ${files[0].length} ${files[0].lastModified}"""
-                        
-                        }
+                        def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
+                        echo """${syftSbom[0].name} ${syftSbom[0].path} ${syftSbom[0].directory} ${syftSbom[0].length} ${syftSbom[0].lastModified}"""
 
                         //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         //def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
@@ -135,9 +133,9 @@ void call() {
             if(shouldFail){
                 error "One or more image scans with Grype failed"
             }
+        }
     }
 }
-
 
 void findSbom() {
     def sbomPattern = ~'json|cyclonedx|json'

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -6,7 +6,7 @@ void call() {
         String outputFormat = config?.report_format ?: 'json'
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
-        Boolean scanSbom = config?.grype.scan_sbom ?: false
+        //Boolean scanSbom = config?.grype.scan_sbom ?: false
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -6,7 +6,7 @@ void call() {
         String outputFormat = config?.report_format ?: 'json'
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
-        Boolean scanSbom = config?.scan_sbom :? false
+        Boolean scanSbom = config?.grype.scan_sbom :? false
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -69,7 +69,8 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json")
-                        println(${img.repo}-${img.tag})
+                        println(img.repo)
+                        println(img.tag)
                         println(syftJsonSbom.size())
                         syftJsonSbom.each { file ->
                         println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -6,7 +6,7 @@ void call() {
         String outputFormat = config?.report_format ?: 'json'
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
-        Boolean scanSbom = config?.grype.scan_sbom :? false
+        Boolean scanSbom = config?.grype.scan_sbom ?: false
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -135,9 +135,9 @@ void call() {
             if(shouldFail){
                 error "One or more image scans with Grype failed"
             }
-        }
     }
 }
+
 
 void findSbom() {
     def sbomPattern = ~'json|cyclonedx|json'

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -67,14 +67,13 @@ void call() {
 
                 def images = get_images_to_build()
                 images.each { img ->
-                    // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
                     if (scanSbom) {
-                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-${raw_results_file}-json.json")
+                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json")
                         println(syftJsonSbom.size())
                         syftJsonSbom.each { file ->
                         println(file.name)}
                     }
-                    
+                    // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
                     String rawResultsFile, transformedResultsFile
                     if (img.repo.contains("/")) {
                         String[] repoImageName = img.repo.split('/')

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -34,7 +34,7 @@ void call() {
             login_to_registry{
                 unstash "workspace"
                 if (scanSbom) {
-                    def syftJsonSbom = findFiles(glob: './*json.json')
+                    def syftJsonSbom = findFiles(glob: '*json.json')
                     ARGS += "sbom:"
                     syftJsonSbom.each { file ->
                     println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -71,7 +71,7 @@ void call() {
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         def files = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json") echo """${files[0].name} ${files[0].path} ${files[0].directory} ${files[0].length} ${files[0].lastModified}"""
-                        println files
+                        println(files)
                         
                         }
 

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -68,7 +68,7 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     if (scanSbom) {
-                        String reportBase = "${img.repo}"-"${img.tag}".replaceAll("/","-")
+                        String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         def syftJsonSbom = findFiles(glob: "${reportBase}-*-json.json")
                         println(syftJsonSbom.size())
                         syftJsonSbom.each { file ->

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -13,7 +13,7 @@ void call() {
         Boolean shouldFail = false 
 
         if (scanSbom) {
-            def files = findFiles(glob: '*json.json')
+            def files = findFiles(glob: './*json.json')
             ARGS += "sbom:"
             files.each { file ->
             println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -13,9 +13,12 @@ void call() {
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
         //test
-        baseDir.eachFileMatch FileType.any, ~/\*json.json/, { names << it.name } 
-        names.each { name ->
-        println(name)}
+        def baseDir = new File('.')
+        baseDir.traverse { File file ->
+        if(file.name.endsWith('.json')) {
+            println file.name
+        }
+        }
         //end
         if (outputFormat != null) {
             ARGS += "-o ${outputFormat} "

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -34,7 +34,7 @@ void call() {
             login_to_registry{
                 unstash "workspace"
                 if (scanSbom) {
-                    def syftJsonSbom = findFiles(glob: './*json.json', excludes: './spdx-json.json')
+                    def syftJsonSbom = findFiles(glob: './*json.json', excludes: './*spdx-json.json')
                     ARGS += "sbom:"
                     files.each { file ->
                     println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -72,9 +72,9 @@ void call() {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-*dx-json.json")
                         if (syftSbom.size() == 0) {
-                            syftSbom += findFiles(glob: "${reportBase}-*-cyclonedx*")
+                            syftSbom = findFiles(glob: "${reportBase}-*-cyclonedx*")
                             if (syftSbom.size() == 0) {
-                                syftSbom += findFiles(glob: "${reportBase}-*-spdx*")
+                                syftSbom = findFiles(glob: "${reportBase}-*-spdx*")
                             }
                         }
                     }

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -34,7 +34,7 @@ void call() {
             login_to_registry{
                 unstash "workspace"
                 if (scanSbom) {
-                    def syftJsonSbom = findFiles(glob: './*json.json', excludes: './*spdx-json.json')
+                    def syftJsonSbom = findFiles(glob: './*json.json')
                     ARGS += "sbom:"
                     syftJsonSbom.each { file ->
                     println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -70,11 +70,9 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        if(findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").findResult != null) {
-                            findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").eachWithIndex {key, value, index ->
-                            println(index)
-                            println(key)
-                            println(value) }
+                        def files = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json") echo """${files[0].name} ${files[0].path} ${files[0].directory} ${files[0].length} ${files[0].lastModified}"""
+                        println files
+                        
                         }
 
                         //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -70,8 +70,11 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").each { file ->
-                        println(file)}
+                        if(findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").findResult != null) {
+                            findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").eachWithIndex {key, value, index ->
+                            println(index key value)}
+                        }
+
                         //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         //def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
                         //if (syftSbom.size() == 0) {

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,7 +7,7 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.scan_sbom ?: false
-        //ArrayList syftSbom = []
+        ArrayList syftSbom = []
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
@@ -70,17 +70,13 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
-                        echo syftSbom
-                        
-
-                        //if (syftSbom.size() == 0) {
-                        //    syftSbom += findFiles(glob: "${reportBase}-*-cyclonedx*")
-                            
-                        //    if (syftSbom.size() == 0) {
-                        //        syftSbom += findFiles(glob: "${reportBase}-*-spdx*")
-                        //  }
-                        //}
+                        syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-*dx-json.json")
+                        if (syftSbom.size() == 0) {
+                            syftSbom += findFiles(glob: "${reportBase}-*-cyclonedx*")
+                            if (syftSbom.size() == 0) {
+                                syftSbom += findFiles(glob: "${reportBase}-*-spdx*")
+                            }
+                        }
                     }
                     // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
                     String rawResultsFile, transformedResultsFile

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -12,13 +12,6 @@ void call() {
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
 
-        if (scanSbom) {
-            def files = findFiles(glob: '**/*json.json')
-            ARGS += "sbom:"
-            files.each { file ->
-            println(file.name)}
-            
-        }
         if (outputFormat != null) {
             ARGS += "-o ${outputFormat} "
             if (outputFormat == 'json') {
@@ -40,6 +33,13 @@ void call() {
         inside_sdp_image(grypeContainer){
             login_to_registry{
                 unstash "workspace"
+                if (scanSbom) {
+                    def files = findFiles(glob: '**/*json.json')
+                    ARGS += "sbom:"
+                    files.each { file ->
+                    println(file.name)}
+                    
+                }
 
                 // Gets environment variable and sets it to a groovy var
                 String HOME = sh (script: 'echo $HOME', returnStdout: true).trim()

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -36,7 +36,7 @@ void call() {
                 if (scanSbom) {
                     def syftJsonSbom = findFiles(glob: './*json.json', excludes: './*spdx-json.json')
                     ARGS += "sbom:"
-                    files.each { file ->
+                    syftJsonSbom.each { file ->
                     println(file.name)}
 
                     

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,7 +7,6 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.scan_sbom ?: false
-        String baseDir = "./"
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -72,7 +72,9 @@ void call() {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         if(findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").findResult != null) {
                             findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").eachWithIndex {key, value, index ->
-                            println(index key value)}
+                            println(index)
+                            println(key)
+                            println(value) }
                         }
 
                         //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -34,11 +34,13 @@ void call() {
             login_to_registry{
                 unstash "workspace"
                 if (scanSbom) {
-                    def files = findFiles(glob: '**/*json.json')
+                    def syftJsonSbom = findFiles(glob: './*json.json', excludes: './spdx-json.json')
                     ARGS += "sbom:"
                     files.each { file ->
                     println(file.name)}
+
                     
+
                 }
 
                 // Gets environment variable and sets it to a groovy var

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -68,7 +68,8 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     if (scanSbom) {
-                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json").replaceAll("/","-")
+                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-*-json.json")
+                        println(${img.repo}-${img.tag})
                         println(syftJsonSbom.size())
                         syftJsonSbom.each { file ->
                         println(file.name)}

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,7 +7,7 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.scan_sbom ?: false
-       //Map syftSbom = [:]
+        //ArrayList syftSbom = []
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
@@ -71,15 +71,15 @@ void call() {
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
                         def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
-                        echo """${syftSbom[0].name} ${syftSbom[0].path} ${syftSbom[0].directory} ${syftSbom[0].length} ${syftSbom[0].lastModified}"""
+                        echo syftSbom
+                        
 
-                        //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        //def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
                         //if (syftSbom.size() == 0) {
-                        //    syftSbom = findFiles(glob: "${reportBase}-*-cyclonedx*")
+                        //    syftSbom += findFiles(glob: "${reportBase}-*-cyclonedx*")
+                            
                         //    if (syftSbom.size() == 0) {
-                        //        syftSbom = findFiles(glob: "${reportBase}-*-spdx*")
-                        //    }
+                        //        syftSbom += findFiles(glob: "${reportBase}-*-spdx*")
+                        //  }
                         //}
                     }
                     // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
@@ -135,9 +135,4 @@ void call() {
             }
         }
     }
-}
-
-void findSbom() {
-    def sbomPattern = ~'json|cyclonedx|json'
-
 }

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -12,7 +12,7 @@ void call() {
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
 
-        if (scan_sbom) {
+        if (scanSbom) {
             def files = findFiles(glob: '*json.json')
             ARGS += "sbom:"
             files.each { file ->

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,6 +7,7 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.scan_sbom ?: false
+        ArrayList syftSbom = []
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
@@ -69,7 +70,7 @@ void call() {
                 images.each { img ->
                     if (scanSbom) {
                         String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx.json")
+                        syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
                         if (syftSbom.size() == 0) {
                             syftSbom = findFiles(glob: "${reportBase}-*-cyclonedx*")
                             if (syftSbom.size() == 0) {

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,7 +7,7 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.scan_sbom ?: false
-        Map syftSbom = [:]
+       //Map syftSbom = [:]
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
@@ -69,14 +69,16 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     if (scanSbom) {
-                        String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
-                        syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
-                        if (syftSbom.size() == 0) {
-                            syftSbom = findFiles(glob: "${reportBase}-*-cyclonedx*")
-                            if (syftSbom.size() == 0) {
-                                syftSbom = findFiles(glob: "${reportBase}-*-spdx*")
-                            }
-                        }
+                        findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json").each { file ->
+                        println(file)}
+                        //String reportBase = "${img.repo}-${img.tag}".replaceAll("/","-")
+                        //def syftSbom = findFiles(glob: "${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json")
+                        //if (syftSbom.size() == 0) {
+                        //    syftSbom = findFiles(glob: "${reportBase}-*-cyclonedx*")
+                        //    if (syftSbom.size() == 0) {
+                        //        syftSbom = findFiles(glob: "${reportBase}-*-spdx*")
+                        //    }
+                        //}
                     }
                     // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
                     String rawResultsFile, transformedResultsFile

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -33,16 +33,6 @@ void call() {
         inside_sdp_image(grypeContainer){
             login_to_registry{
                 unstash "workspace"
-                if (scanSbom) {
-                    def syftJsonSbom = findFiles(glob: '*json.json', excludes: '*spdx-json.json')
-                    ARGS += "sbom:"
-                    println(syftJsonSbom.size())
-                    syftJsonSbom.each { file ->
-                    println(file.name)}
-
-                    
-
-                }
 
                 // Gets environment variable and sets it to a groovy var
                 String HOME = sh (script: 'echo $HOME', returnStdout: true).trim()
@@ -78,6 +68,13 @@ void call() {
                 def images = get_images_to_build()
                 images.each { img ->
                     // Use $img.repo to help name our results uniquely. Checks to see if a forward slash exists and splits the string at that location.
+                    if (scanSbom) {
+                        def syftJsonSbom = findFiles(glob: "${img.repo}-${img.tag}-${raw_results_file}-json.json")
+                        println(syftJsonSbom.size())
+                        syftJsonSbom.each { file ->
+                        println(file.name)}
+                    }
+                    
                     String rawResultsFile, transformedResultsFile
                     if (img.repo.contains("/")) {
                         String[] repoImageName = img.repo.split('/')

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -7,7 +7,7 @@ void call() {
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
         Boolean scanSbom = config?.scan_sbom ?: false
-        ArrayList syftSbom = []
+        Map syftSbom = [:]
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails

--- a/libraries/grype/steps/container_image_scan.groovy
+++ b/libraries/grype/steps/container_image_scan.groovy
@@ -6,14 +6,12 @@ void call() {
         String outputFormat = config?.report_format ?: 'json'
         String severityThreshold = config?.fail_on_severity ?: 'high'
         String grypeConfig = config?.grype_config
-        //Boolean scanSbom = config?.grype.scan_sbom ?: false
+        Boolean scanSbom = config?.grype.scan_sbom ?: false
         String resultsFileFormat = ".txt"
         String ARGS = ""
         // is flipped to True if an image scan fails
         Boolean shouldFail = false 
-        //test
-        println(config.syft.raw_results_file)
-        //end
+
         if (outputFormat != null) {
             ARGS += "-o ${outputFormat} "
             if (outputFormat == 'json') {

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -60,7 +60,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             ContainerImageScan()
         then:
             1 * getPipelineMock("echo")("Grype file explicitly specified in pipeline_config.groovy")
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config \/testPath\/grype.yaml >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config \/testPath\/grype.yaml > .*/})
     }
 
     def "Grype config is found at current dir .grype.yaml" () {
@@ -75,7 +75,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("fileExists")(".grype.yaml") >> true
             1 * getPipelineMock("echo")("Found .grype.yaml")
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config .grype.yaml >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config .grype.yaml > .*/})
     }
 
     def "Grype config is found at .grype/config.yaml" () {
@@ -90,7 +90,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("fileExists")(".grype/config.yaml") >> true
             1 * getPipelineMock("echo")("Found .grype/config.yaml")
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config .grype\/config.yaml >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config .grype\/config.yaml > .*/})
     }
 
     def "Grype config is found at user Home path/.grype.yaml" () {
@@ -105,7 +105,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("fileExists")("/home/.grype.yaml") >> true
             1 * getPipelineMock("echo")("Found ~/.grype.yaml")
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config \/home\/.grype.yaml >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config \/home\/.grype.yaml > .*/})
     }
 
     def "Grype config found at <XDG_CONFIG_HOME>/grype/config.yaml" () {
@@ -120,16 +120,16 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("fileExists")("/xdg/grype/config.yaml") >> true
             1 * getPipelineMock("echo")("Found <XDG_CONFIG_HOME>/grype/config.yaml")
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config \/xdg\/grype\/config.yaml >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* --config \/xdg\/grype\/config.yaml > .*/})
     }
 
     def "Check each image is scanned as expected when no extra config is present" () {
         when:
             ContainerImageScan()
         then:
-            1 * getPipelineMock("sh")("grype test_registry/image1_repo:4321dcba -o json --fail-on high  >> image1_repo-grype-scan-results.json")
-            1 * getPipelineMock("sh")("grype test_registry/image2_repo:4321dcbb -o json --fail-on high  >> image2_repo-grype-scan-results.json")
-            1 * getPipelineMock("sh")("grype test_registry/image3_repo/qwerty:4321dcbc -o json --fail-on high  >> qwerty-grype-scan-results.json")
+            1 * getPipelineMock("sh")("grype test_registry/image1_repo:4321dcba -o json --fail-on high  > image1_repo-grype-scan-results.json")
+            1 * getPipelineMock("sh")("grype test_registry/image2_repo:4321dcbb -o json --fail-on high  > image2_repo-grype-scan-results.json")
+            1 * getPipelineMock("sh")("grype test_registry/image3_repo/qwerty:4321dcbc -o json --fail-on high  > qwerty-grype-scan-results.json")
     }
 
     def "Test json format and negligible severity" () {
@@ -138,7 +138,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
         when:
             ContainerImageScan()
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o json --fail-on negligible  >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o json --fail-on negligible  > .*/})
     }
 
     def "Test table format and low severity" () {
@@ -147,7 +147,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
         when:
             ContainerImageScan()
         then:
-            (1.._ ) * getPipelineMock("sh")({it =~ /^grype .* -o table --fail-on low  >> .*/})
+            (1.._ ) * getPipelineMock("sh")({it =~ /^grype .* -o table --fail-on low  > .*/})
     }
 
     def "Test cyclonedx format and medium severity" () {
@@ -156,7 +156,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
         when:
             ContainerImageScan()
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o cyclonedx --fail-on medium  >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o cyclonedx --fail-on medium  > .*/})
     }
 
     def "Test table format and high severity" () {
@@ -165,7 +165,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
         when:
             ContainerImageScan()
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o table --fail-on high  >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o table --fail-on high  > .*/})
     }
 
     def "Test cyclonedx format and critical severity" () {
@@ -174,7 +174,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
         when:
             ContainerImageScan()
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o cyclonedx --fail-on critical  >> .*/})
+            (1.._) * getPipelineMock("sh")({it =~ /^grype .* -o cyclonedx --fail-on critical  > .*/})
     }
 
     def "Test Archive artifacts works as expected for json format and not null grype config" () {
@@ -205,11 +205,6 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("stash")("workspace")
             1 * getPipelineMock("error")(_)          
     }
-/*
-repo: "image1_repo", context: "image1", tag: "4321dcba"]
-            images << [registry: "test_registry", repo: "image2_repo", context: "image2", tag: "4321dcbb"]
-            images << [registry: "test_registry", repo: "image3_repo/qwerty", context: "image3", tag: "4321dcbc"]
-*/
 
     def "Test scanning syft JSON SBOM artifact" () {
         given:

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -219,23 +219,12 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
     def "Test scanning syft JSON SBOM artifact" () {
         given:
             ContainerImageScan.getBinding().setVariable("config", [scan_sbom: true])
-            //explicitlyMockPipelineVariable("syftSbom")
             getPipelineMock("findFiles")([glob:'image1_repo-4321dcba-*-json.json', excludes:'image1_repo-4321dcba-*-spdx-json.json']) >> ['image1_repo-4321dcba-this is a test-json.json']
-            //getPipelineMock("syftSbom")() >> {
-            //    def syftSbom = findFiles([glob:'image1_repo-4321dcba-*-json.json', excludes:'image1_repo-4321dcba-*-spdx-json.json'])
-            //    return syftSbom
-            //}
-            
+                
         when:
-            ContainerImageScan()
-            //ContainerImageScan.getBinding().setVariable("syftSbom", ['image1_repo-4321dcba-anything-json.json'])
-            
+            ContainerImageScan()            
 
         then:
-            //1 * getPipelineMock("sh")({it =~ /^grype sbom:image1*/})
-            //1 * getPipelineMock("sh")({it =~ /^grype sbom:image2*/})
-            //1 * getPipelineMock("sh")({it =~ /^grype sbom:image3*/})
-
             1 * getPipelineMock("echo")(['image1_repo-4321dcba-this is a test-json.json'])
             
 
@@ -255,3 +244,10 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
             //getPipelineMock("findFiles")([glob:"image1_repo-4321dcba-*-json.json", excludes:"image1_repo-4321dcba-*-spdx-json.json"]) >> [[path: 'image1_repo-4321dcba-*-json.json']]
             //getPipelineMock('syftSbom.size')(1)
             //getPipelineMock("findFiles")(_) >> ['image1_repo-4321dcbb-anything-json.json','image2_repo-4321dcba-anything-json.json']
+
+            //getPipelineMock("syftSbom")() >> {
+            //    def syftSbom = findFiles([glob:'image1_repo-4321dcba-*-json.json', excludes:'image1_repo-4321dcba-*-spdx-json.json'])
+            //    return syftSbom
+            //}
+
+            //explicitlyMockPipelineVariable("syftSbom")

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -22,8 +22,8 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
         getPipelineMock("sh")([script: 'echo $HOME', returnStdout: true]) >> "/home"
         getPipelineMock("sh")([script: 'echo $XDG_CONFIG_HOME', returnStdout: true]) >> "/xdg"
         //getPipelineMock("sh")([script: 'touch image1_repo-4321dcba-anything-json.json'])
-        getPipelineMock("sh")([script: 'touch image1_repo-4321dcba-anything-cyclonedx.xml'])
-        getPipelineMock("sh")([script: 'touch image1_repo-4321dcba-anything-spdx.json'])
+        //getPipelineMock("sh")([script: 'touch image1_repo-4321dcba-anything-cyclonedx.xml'])
+        //getPipelineMock("sh")([script: 'touch image1_repo-4321dcba-anything-spdx.json'])
 
         getPipelineMock("get_images_to_build")() >> {
             def images = []
@@ -219,21 +219,24 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
     def "Test scanning syft JSON SBOM artifact" () {
         given:
             ContainerImageScan.getBinding().setVariable("config", [scan_sbom: true])
-            //getPipelineMock("findFiles")([glob: '${reportBase}-*-cyclonedx*']) >> ['1']
-            //getPipelineMock("findFiles")([glob: '${reportBase}-*-spdx*']) >> ['2']
-            ContainerImageScan.getBinding().setVariable("syftSbom",[[path: 'image1_repo-4321dcba-*-json.json']])
             //explicitlyMockPipelineVariable("syftSbom")
-            //getPipelineMock("findFiles")([glob:"image1_repo-4321dcba-*-json.json", excludes:"image1_repo-4321dcba-*-spdx-json.json"]) >> [[path: 'image1_repo-4321dcba-*-json.json']]
+            getPipelineMock("findFiles")([glob:'image1_repo-4321dcba-*-json.json', excludes:'image1_repo-4321dcba-*-spdx-json.json']) >> ['image1_repo-4321dcba-this is a test-json.json']
+            //getPipelineMock("syftSbom")() >> {
+            //    def syftSbom = findFiles([glob:'image1_repo-4321dcba-*-json.json', excludes:'image1_repo-4321dcba-*-spdx-json.json'])
+            //    return syftSbom
+            //}
             
         when:
-            //ArrayList syftSbom = ['image1_repo-4321dcba-anything-json.json']
             ContainerImageScan()
-            //getPipelineMock("findFiles")([glob:"image1_repo-4321dcba-*-json.json", excludes:"image1_repo-4321dcba-*-spdx-json.json"]) >> [[path: 'image1_repo-4321dcba-*-json.json']]
-            //getPipelineMock('syftSbom.size')(1)
-            //getPipelineMock("findFiles")(_) >> ['image1_repo-4321dcbb-anything-json.json','image2_repo-4321dcba-anything-json.json']
+            //ContainerImageScan.getBinding().setVariable("syftSbom", ['image1_repo-4321dcba-anything-json.json'])
+            
 
         then:
-            3 * getPipelineMock("sh")({it =~ /^grype */})
+            //1 * getPipelineMock("sh")({it =~ /^grype sbom:image1*/})
+            //1 * getPipelineMock("sh")({it =~ /^grype sbom:image2*/})
+            //1 * getPipelineMock("sh")({it =~ /^grype sbom:image3*/})
+
+            1 * getPipelineMock("echo")(['image1_repo-4321dcba-this is a test-json.json'])
             
 
     }
@@ -241,3 +244,14 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
 
 
 
+//getPipelineMock("findFiles")([glob: '${reportBase}-*-cyclonedx*']) >> ['1']
+            //getPipelineMock("findFiles")([glob: '${reportBase}-*-spdx*']) >> ['2']
+            //ContainerImageScan.getBinding().setVariable("syftSbom",[[path: 'image1_repo-4321dcba-*-json.json']])
+            //getPipelineMock("syftSbom").call("findFiles", ([glob:"${reportBase}-*-json.json", excludes: "${reportBase}-*-spdx-json.json"])) >> [path: 'image1_repo-4321dcba-*-json.json']
+            //explicitlyMockPipelineVariable("syftSbom")
+            //getPipelineMock("findFiles")([glob:"image1_repo-4321dcba-*-json.json", excludes:"image1_repo-4321dcba-*-spdx-json.json"]) >> [[path: 'image1_repo-4321dcba-*-json.json']]
+
+
+            //getPipelineMock("findFiles")([glob:"image1_repo-4321dcba-*-json.json", excludes:"image1_repo-4321dcba-*-spdx-json.json"]) >> [[path: 'image1_repo-4321dcba-*-json.json']]
+            //getPipelineMock('syftSbom.size')(1)
+            //getPipelineMock("findFiles")(_) >> ['image1_repo-4321dcbb-anything-json.json','image2_repo-4321dcba-anything-json.json']

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -223,7 +223,7 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
             ContainerImageScan()            
 
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype sbom:.*/})
+            (1..3) * getPipelineMock("sh")({it =~ /^grype sbom:image.*/})
     }
 
         def "Test scanning syft Cyclonedx SBOM artifact" () {
@@ -241,10 +241,10 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
             ContainerImageScan()            
 
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype sbom:.*/})
+            (1..3) * getPipelineMock("sh")({it =~ /^grype sbom:.*cyclonedx*/})
     }
 
-    def "Test scanning syft Cyclonedx SBOM artifact" () {
+    def "Test scanning syft SPDX SBOM artifact" () {
         given:
             ContainerImageScan.getBinding().setVariable("config", [scan_sbom: true])
             getPipelineMock("findFiles")([glob:'image1_repo-4321dcba-*-json.json', excludes:'image1_repo-4321dcba-*-*dx-json.json']) >> []
@@ -262,6 +262,6 @@ repo: "image1_repo", context: "image1", tag: "4321dcba"]
             ContainerImageScan()            
 
         then:
-            (1.._) * getPipelineMock("sh")({it =~ /^grype sbom:.*/})
+            (1..3) * getPipelineMock("sh")({it =~ /^grype sbom:.*spdx*/})
     }
 }

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -196,7 +196,7 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
     def "Test that error handling works as expected" () {
         given:
             explicitlyMockPipelineStep("Exception")//("Failed: java.lang.Exception: test")
-            getPipelineMock("sh")("grype test_registry/image1_repo:4321dcba -o json --fail-on high  >> image1_repo-grype-scan-results.json") >> {throw new Exception("test")}
+            getPipelineMock("sh")("grype test_registry/image1_repo:4321dcba -o json --fail-on high  > image1_repo-grype-scan-results.json") >> {throw new Exception("test")}
         when:
             ContainerImageScan()
         then:

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -206,6 +206,14 @@ public class ContainerImageScanSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("stash")("workspace")
             1 * getPipelineMock("error")(_)          
     }
+
+    def "Test scanning syft JSON SBOM artifact" () {
+        given:
+            ContainerImageScan.getBinding().setVariable("config", [scan_sbom: true])
+            ContainerImageScan.getBinding().setVariable("syftSbom", [])
+            
+
+    }
 }
 
 

--- a/libraries/syft/steps/generate_sbom.groovy
+++ b/libraries/syft/steps/generate_sbom.groovy
@@ -52,7 +52,7 @@ void call() {
                         error("SBOM Stage Failed")
                       }
                       else {
-                        artifacts.replaceAll(",$", "")
+                        artifacts.replaceAll(",\$", "")
                         println(artifacts)
                         archiveArtifacts artifacts: "${artifacts}"
                       }

--- a/libraries/syft/steps/generate_sbom.groovy
+++ b/libraries/syft/steps/generate_sbom.groovy
@@ -6,57 +6,58 @@
 package libraries.syft.steps
 
 void call() {
-    stage('Generate SBOM using Syft') {
-        //Import settings from config
-        String raw_results_file = config?.raw_results_file ?: 'syft-sbom-results' // leave off file extension so that it can be added based off off selected formats
-        String sbom_container = config?.sbom_container ?: 'syft:0.47.0'
-        ArrayList sbom_format = config?.sbom_format ?: ["json"]
-        String artifacts = ""
-        boolean shouldFail = false
+  stage('Generate SBOM using Syft') {
+    //Import settings from config
+    String raw_results_file = config?.raw_results_file ?: 'syft-sbom-results' // leave off file extension so that it can be added based off off selected formats
+    String sbom_container = config?.sbom_container ?: 'syft:0.47.0'
+    ArrayList sbom_format = config?.sbom_format ?: ["json"]
+    String artifacts = ""
+    boolean shouldFail = false
 
-        //Get list of images to scan (assuming same set built by Docker)
-        def images = get_images_to_build()
-        inside_sdp_image "${sbom_container}", {
-            login_to_registry {
-                unstash "workspace"
-                images.each { img ->
-                    String ARGS = "-q"
-                    String results_name = "${img.repo}-${img.tag}-${raw_results_file}".replaceAll("/","-")
-                      sbom_format.each { format ->
-                        String formatter = ""
-                        if(format == "json" || format == "cyclonedx-json" || format == "spdx-json" || format == "github") {
-                          formatter += "${results_name}-${format}.json"
-                        }
-                        else if(format == "text" || format == "spdx-tag-value" || format == "table") {
-                          formatter += "${results_name}-${format}.txt"
-                        }
-                        else if (format == "cyclonedx-xml") {
-                          formatter += "${results_name}-${format}.xml"
-                        }
-
-                        ARGS += " -o ${format}=${formatter} "
-                        artifacts += "${formatter},"
-                      }
-
-                    // perform the syft scan
-                    try {
-                      sh "syft ${img.registry}/${img.repo}:${img.tag} ${ARGS}"
-                    }
-                    catch(Exception err) {
-                      shouldFail = true
-                      echo "SBOM generation Failed: ${err}"  
-                    }
-                    finally {
-                      if(shouldFail){
-                        error("SBOM Stage Failed")
-                      }
-                      else {
-                        archiveArtifacts artifacts: "${artifacts.replaceAll(',$', "")}"
-                      }
-                    }
-                }
-                stash "workspace"
+    //Get list of images to scan (assuming same set built by Docker)
+    def images = get_images_to_build()
+    inside_sdp_image "${sbom_container}", {
+      login_to_registry {
+        unstash "workspace"
+        images.each { img ->
+          String ARGS = "-q"
+          String results_name = "${img.repo}-${img.tag}-${raw_results_file}".replaceAll("/","-")
+          sbom_format.each { format ->
+            String formatter = ""
+            if(format == "json" || format == "cyclonedx-json" || format == "spdx-json" || format == "github") {
+              formatter += "${results_name}-${format}.json"
             }
+            else if(format == "text" || format == "spdx-tag-value" || format == "table") {
+              formatter += "${results_name}-${format}.txt"
+            }
+            else if (format == "cyclonedx-xml") {
+              formatter += "${results_name}-${format}.xml"
+            }
+
+            ARGS += " -o ${format}=${formatter} "
+            artifacts += "${formatter},"
+          }
+
+          // perform the syft scan
+          try {
+            sh "syft ${img.registry}/${img.repo}:${img.tag} ${ARGS}"
+          }
+          catch(Exception err) {
+            shouldFail = true
+            echo "SBOM generation Failed: ${err}"
+          }
+          finally {
+            if(shouldFail){
+              error("SBOM Stage Failed")
+            }
+            else {
+              archiveArtifacts artifacts: "${artifacts.replaceAll(',$', "")}"
+            }
+          }
         }
+
+        stash "workspace"
+      }
     }
+  }
 }

--- a/libraries/syft/steps/generate_sbom.groovy
+++ b/libraries/syft/steps/generate_sbom.groovy
@@ -52,7 +52,7 @@ void call() {
                         error("SBOM Stage Failed")
                       }
                       else {
-                        artifacts.replaceAll(",\$", "")
+                        artifacts.replaceAll(',$', "")
                         println(artifacts)
                         archiveArtifacts artifacts: "${artifacts}"
                       }

--- a/libraries/syft/steps/generate_sbom.groovy
+++ b/libraries/syft/steps/generate_sbom.groovy
@@ -52,8 +52,7 @@ void call() {
                         error("SBOM Stage Failed")
                       }
                       else {
-                        artifacts.replaceAll(',$', "")
-                        println(artifacts)
+                        println(artifacts.replaceAll(',$', ""))
                         archiveArtifacts artifacts: "${artifacts}"
                       }
                     }

--- a/libraries/syft/steps/generate_sbom.groovy
+++ b/libraries/syft/steps/generate_sbom.groovy
@@ -52,8 +52,7 @@ void call() {
                         error("SBOM Stage Failed")
                       }
                       else {
-                        println(artifacts.replaceAll(',$', ""))
-                        archiveArtifacts artifacts: "${artifacts}"
+                        archiveArtifacts artifacts: "${artifacts.replaceAll(',$', "")}"
                       }
                     }
                 }


### PR DESCRIPTION
# PR Details
Add Grype ability to scan an SBOM file Also fixes bug from BASS-1328
<!--- Provide a general summary of your changes -->

## Description
adds logic to locate an acceptable SBOM artifact for scanning when sbom_scan equals true, otherwise grype scans the image from the container registry. Also changes the grype commands output redirection from >> to > to fix duplicate CVEs causing the transform script to error out.
<!--- Describe your changes in detail -->

## How Has This Been Tested
In a JTE Jenkins pipeline and with Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
