### PR TITLE
Cypress test repo subdirectory fix

### DIFF
--- a/libraries/cypress/steps/end_to_end_test.groovy
+++ b/libraries/cypress/steps/end_to_end_test.groovy
@@ -51,11 +51,19 @@ void call() {
     // run tests inside container
     docker.withRegistry("${containerRegistry}", "${containerRegistryCreds}") {
       docker.image("${containerImage}").inside {
-        sh """
+        String runTests = """
           npm ci
           \$(npm bin)/cypress verify
           ${npmScript}
         """
+        if (testRepoCreds != '') {
+          dir('test_repo_dir') {
+            sh runTests
+          }
+        }
+        else {
+          sh runTests
+        }
       }
     }
 


### PR DESCRIPTION
# PR Details

Bugfixing Cypress subdirectory check

## Description

When using a separate test repo, it is checked out into a new subdirectory: `test_repo_dir`
Configured Cypress tests need to be run from that subdirectory, requiring a variable check and `dir() {`, as needed

## How Has This Been Tested

Locally

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
