### PR TITLE
Additional Cypress subdirectory fix

### DIFF
--- a/libraries/cypress/steps/end_to_end_test.groovy
+++ b/libraries/cypress/steps/end_to_end_test.groovy
@@ -46,6 +46,8 @@ void call() {
       else {
         sh prepTestRepo
       }
+      //update reportPath
+      reportPath = "test_repo_dir/" + reportPath
     }
 
     // run tests inside container


### PR DESCRIPTION
# PR Details

Bugfix: missed one subdirectory reference

## Description

Updated configured `report_path` variable in cases where an external test repo is set (and cloned into a newly-created subdirectory)

## How Has This Been Tested

Local and in-house dev environments

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
