### PR TITLE
OWASP Dep Check: change default image tag from 'latest'

### DIFF
--- a/libraries/owasp_dep_check/README.md
+++ b/libraries/owasp_dep_check/README.md
@@ -30,7 +30,7 @@ OWASP Dependency Check Library Configuration Options
 | `cvss_threshold`         | A number between 0 and 10, inclusive, representing the failure threshold for vulnerabilities (**note:** will never fail unless a threshold is provided) |                                    |
 | `allow_suppression_file` | Allows whitelisting vulnerabilities using a suppression XML file                                                                                        | `true`                             |
 | `suppression_file`       | Path to the suppression file (see [here](https://jeremylong.github.io/DependencyCheck/general/suppression.html) for how to create a suppression file)   | `dependency-check-suppression.xml` |
-| `image_tag`              | The tag for the scanner Docker image used                                                                                                               | `latest`                           |
+| `image_tag`              | The tag for the scanner Docker image used                                                                                                               | `7.3.0-8.6-2`                      |
 
 ## Example Configuration Snippet
 

--- a/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
+++ b/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
@@ -25,7 +25,7 @@ void call() {
       }
     }
 
-    String image_tag = config?.image_tag ?: "latest"
+    String image_tag = config?.image_tag ?: "7.3.0-8.6-2"
     inside_sdp_image "owasp-dep-check:$image_tag", {
       unstash "workspace"
 


### PR DESCRIPTION
# PR Details

Getting rid of `latest` default image tag in the OWASP Dependency Check library step.

## Description

While the library step image could be overridden, the default value, `latest` could introduce breaking changes without warning. Have updated the step to use the current stable image tag from our GitHub packages registry: `7.3.0-8.6-2`

## How Has This Been Tested

Locally

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
