### PR TITLE
Added a new Docker build strategy to support multiple Dockerfiles and Dockerfiles with custom file names

### DIFF
--- a/libraries/docker/README.md
+++ b/libraries/docker/README.md
@@ -18,12 +18,12 @@ The Docker library will build Docker images and push them into a Docker reposito
 | `login_to_registry()`   | logs in to the configured container registry                                                                                |
 | `retag()`               | retags the container images determined by `get_images_to_build()`                                                           |
 
-## Example Configuration Snippet
+## Example Configuration Snippets
 
 ---
 
 ```groovy
-libraries{
+libraries {
   docker {
     build_strategy = "dockerfile"
     registry = "docker-registry.default.svc:5000"
@@ -31,8 +31,8 @@ libraries{
     repo_path_prefix = "proj-images"
     image_name = "my-container-image"
     remove_local_image = true
-    build_args{
-      GITHUB_TOKEN{
+    build_args {
+      GITHUB_TOKEN {
         type = "credential"
         id = "github_token"
       }
@@ -42,29 +42,53 @@ libraries{
 }
 ```
 
+```groovy
+libraries {
+  docker {
+    build_strategy = 'dockerfiles'
+    registry = "docker-registry.default.svc:5000"
+    cred = "openshift-docker-registry"
+    repo_path_prefix = "proj-images"
+    image_name = "my-container-image"
+    remove_local_image = true
+    dockerfiles {
+      backend {
+        context = '.'
+        dockerfile = 'Dockerfile.backend'
+      }
+      frontend {
+        context = '.'
+        dockerfile = 'Dockerfile.frontend'
+      }
+    }
+  }
+}
+```
+
 ## Configuration
 
 ---
 
-| Field                      | Description                                                                                                  | Default Value       | Required |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------- | -------- |
-| `build_strategy`           | Sets how the library will build the container image(s); must be `dockerfile`, `docker-compose`, or `modules` | `dockerfile`        | No       |
-| `registry`                 | Where the container images produced during the pipeline builds are going to be pushed to                     |                     | Yes      |
-| `registry_protocol`        | the protocol to prepend to the `registry` when authenticating to the container registry                      | `"https://"`        | No       |
-| `cred`                     | Credentials used for the repository where different docker pipeline tools are stored                         |                     | Yes      |
-| `repo_path_prefix`         | The part of the repository name between the registry name and the last forward-slash                         | ""                  | No       |
-| `image_name`               | Name of the container image being built                                                                      | `env.REPO_NAME`     | No       |
-| `remove_local_image`       | Determines if the pipeline should remove the local image after building or retagging                         | `false`             | No       |
-| `build_args`               | A block of build arguments to pass to `docker build` (for more information, see below)                       |                     | No       |
-| `setExperimentalFlag`      | If the docker version only has buildx as an experimental feature then this allows that flag to be set        | `false`             | No       |
-| `same_repo_different_tags` | When building multiple images don't change the repository name but append the key name to the tag            | `false`             | No       |
-| `buildx[].name { }`        | the key name to the map of the specific element of the buildx array                                          |                     | Yes      |
-| `buildx[].useLatestTag`    | Add an additional latest tag to the image being built on top of the other tag                                | `false`             | No       |
-| `buildx[].tag`             | Override the tag with a string                                                                               | Git SHA from commit | No       |
-| `buildx[].context`         | Dockerfile context for that image                                                                            | `"."`               | No       |
-| `buildx[].dockerfile_path` | Dockerfile location and name for that image                                                                  | `"Dockerfile"`      | No       |
-| `buildx[].platforms`       | array of platforms to be built for that image                                                                | `linux/amd64`       | No       |
-| `buildx[].build_args`      | A block of build arguments to pass for that element to `docker buildx` (for more information, see below)     |                     |          |
+| Field                      | Description                                                                                                                 | Default Value       | Required |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------- | -------- |
+| `build_strategy`           | Sets how the library will build the container image(s); must be `dockerfile`, `dockerfiles`, `docker-compose`, or `modules` | `dockerfile`        | No       |
+| `registry`                 | Where the container images produced during the pipeline builds are going to be pushed to                                    |                     | Yes      |
+| `registry_protocol`        | the protocol to prepend to the `registry` when authenticating to the container registry                                     | `"https://"`        | No       |
+| `cred`                     | Credentials used for the repository where different docker pipeline tools are stored                                        |                     | Yes      |
+| `repo_path_prefix`         | The part of the repository name between the registry name and the last forward-slash                                        | ""                  | No       |
+| `image_name`               | Name of the container image being built                                                                                     | `env.REPO_NAME`     | No       |
+| `remove_local_image`       | Determines if the pipeline should remove the local image after building or retagging                                        | `false`             | No       |
+| `build_args`               | A block of build arguments to pass to `docker build` (for more information, see below)                                      |                     | No       |
+| `setExperimentalFlag`      | If the docker version only has buildx as an experimental feature then this allows that flag to be set                       | `false`             | No       |
+| `same_repo_different_tags` | When building multiple images don't change the repository name but append the key name to the tag                           | `false`             | No       |
+| `dockerfiles`              | A map of Dockerfiles to build for the `dockerfiles` build strategy                                                          |                     | No       |
+| `buildx[].name { }`        | the key name to the map of the specific element of the buildx array                                                         |                     | Yes      |
+| `buildx[].useLatestTag`    | Add an additional latest tag to the image being built on top of the other tag                                               | `false`             | No       |
+| `buildx[].tag`             | Override the tag with a string                                                                                              | Git SHA from commit | No       |
+| `buildx[].context`         | Dockerfile context for that image                                                                                           | `"."`               | No       |
+| `buildx[].dockerfile_path` | Dockerfile location and name for that image                                                                                 | `"Dockerfile"`      | No       |
+| `buildx[].platforms`       | array of platforms to be built for that image                                                                               | `linux/amd64`       | No       |
+| `buildx[].build_args`      | A block of build arguments to pass for that element to `docker buildx` (for more information, see below)                    |                     |          |
 
 ## Build Arguments
 

--- a/libraries/docker/README.md
+++ b/libraries/docker/README.md
@@ -10,13 +10,13 @@ The Docker library will build Docker images and push them into a Docker reposito
 
 ---
 
-| Step | Description |
-| ----------- | ----------- |
-| `build()` | builds a container image, tagging it with the Git SHA, and pushes the image to the defined registry |
-| `buildx()` | builds a multi-architecture image using Buildx emulation, and pushes the image or images to the defined registry |
+| Step                    | Description                                                                                                                 |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `build()`               | builds a container image, tagging it with the Git SHA, and pushes the image to the defined registry                         |
+| `buildx()`              | builds a multi-architecture image using Buildx emulation, and pushes the image or images to the defined registry            |
 | `get_images_to_build()` | inspects the source code repository based upon the configured `build_strategy` to determine which container images to build |
-| `login_to_registry()` | logs in to the configured container registry |
-| `retag()` | retags the container images determined by `get_images_to_build()` |
+| `login_to_registry()`   | logs in to the configured container registry                                                                                |
+| `retag()`               | retags the container images determined by `get_images_to_build()`                                                           |
 
 ## Example Configuration Snippet
 
@@ -46,25 +46,25 @@ libraries{
 
 ---
 
-| Field | Description | Default Value | Required |
-| ----------- | ----------- | ----------- | ----------- |
-| `build_strategy` | Sets how the library will build the container image(s); must be `dockerfile`, `docker-compose`, or `modules` | `dockerfile` | No |
-| `registry` | Where the container images produced during the pipeline builds are going to be pushed to |  | Yes |
-| `registry_protocol` | the protocol to prepend to the `registry` when authenticating to the container registry | `"https://"` | No |
-| `cred` | Credentials used for the repository where different docker pipeline tools are stored |  | Yes |
-| `repo_path_prefix` | The part of the repository name between the registry name and the last forward-slash | "" | No |
-| `image_name` | Name of the container image being built | `env.REPO_NAME` | No |
-| `remove_local_image` | Determines if the pipeline should remove the local image after building or retagging | `false` | No |
-| `build_args` | A block of build arguments to pass to `docker build` (for more information, see below) | | No |
-| `setExperimentalFlag` | If the docker version only has buildx as an experimental feature then this allows that flag to be set | `false` | No |
-| `same_repo_different_tags` | When building multiple images don't change the repository name but append the key name to the tag | `false` | No |
-| `buildx[].name { }` | the key name to the map of the specific element of the buildx array |  | Yes |
-| `buildx[].useLatestTag` | Add an additional latest tag to the image being built on top of the other tag | `false` | No |
-| `buildx[].tag` | Override the tag with a string | Git SHA from commit | No |
-| `buildx[].context` | Dockerfile context for that image | `"."` | No |
-| `buildx[].dockerfile_path` | Dockerfile location and name for that image | `"Dockerfile"` | No |
-| `buildx[].platforms` | array of platforms to be built for that image | `linux/amd64` | No |
-| `buildx[].build_args` | A block of build arguments to pass for that element to `docker buildx` (for more information, see below) | | |
+| Field                      | Description                                                                                                  | Default Value       | Required |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------- | -------- |
+| `build_strategy`           | Sets how the library will build the container image(s); must be `dockerfile`, `docker-compose`, or `modules` | `dockerfile`        | No       |
+| `registry`                 | Where the container images produced during the pipeline builds are going to be pushed to                     |                     | Yes      |
+| `registry_protocol`        | the protocol to prepend to the `registry` when authenticating to the container registry                      | `"https://"`        | No       |
+| `cred`                     | Credentials used for the repository where different docker pipeline tools are stored                         |                     | Yes      |
+| `repo_path_prefix`         | The part of the repository name between the registry name and the last forward-slash                         | ""                  | No       |
+| `image_name`               | Name of the container image being built                                                                      | `env.REPO_NAME`     | No       |
+| `remove_local_image`       | Determines if the pipeline should remove the local image after building or retagging                         | `false`             | No       |
+| `build_args`               | A block of build arguments to pass to `docker build` (for more information, see below)                       |                     | No       |
+| `setExperimentalFlag`      | If the docker version only has buildx as an experimental feature then this allows that flag to be set        | `false`             | No       |
+| `same_repo_different_tags` | When building multiple images don't change the repository name but append the key name to the tag            | `false`             | No       |
+| `buildx[].name { }`        | the key name to the map of the specific element of the buildx array                                          |                     | Yes      |
+| `buildx[].useLatestTag`    | Add an additional latest tag to the image being built on top of the other tag                                | `false`             | No       |
+| `buildx[].tag`             | Override the tag with a string                                                                               | Git SHA from commit | No       |
+| `buildx[].context`         | Dockerfile context for that image                                                                            | `"."`               | No       |
+| `buildx[].dockerfile_path` | Dockerfile location and name for that image                                                                  | `"Dockerfile"`      | No       |
+| `buildx[].platforms`       | array of platforms to be built for that image                                                                | `linux/amd64`       | No       |
+| `buildx[].build_args`      | A block of build arguments to pass for that element to `docker buildx` (for more information, see below)     |                     |          |
 
 ## Build Arguments
 

--- a/libraries/docker/steps/build.groovy
+++ b/libraries/docker/steps/build.groovy
@@ -26,7 +26,7 @@ void call(){
         def images = get_images_to_build()
         withBuildArgs{ args ->
           images.each{ img ->
-            sh "docker build ${img.context} -t ${img.registry}/${img.repo}:${img.tag} ${args}"
+            sh "docker build -f ${img.dockerfile} ${img.context} -t ${img.registry}/${img.repo}:${img.tag} ${args}"
             sh "docker push ${img.registry}/${img.repo}:${img.tag}"
             if (remove_local_image) sh "docker rmi -f ${img.registry}/${img.repo}:${img.tag} 2> /dev/null"
           }

--- a/libraries/docker/test/BuildSpec.groovy
+++ b/libraries/docker/test/BuildSpec.groovy
@@ -17,8 +17,8 @@ public class BuildSpec extends JTEPipelineSpecification {
 
     getPipelineMock("get_images_to_build")() >> {
       def images = []
-      images << [registry: "reg1", repo: "repo1", context: "context1", tag: "tag1"]
-      images << [registry: "reg2", repo: "repo2", context: "context2", tag: "tag2"]
+      images << [registry: "reg1", repo: "repo1", context: "context1", tag: "tag1", dockerfile: "Dockerfile"]
+      images << [registry: "reg2", repo: "repo2", context: "context2", tag: "tag2", dockerfile: "Dockerfile.test"]
       return images
     }
   }
@@ -45,8 +45,8 @@ public class BuildSpec extends JTEPipelineSpecification {
     when:
       Build()
     then:
-      1 * getPipelineMock("sh")("docker build context1 -t reg1/repo1:tag1 ")
-      1 * getPipelineMock("sh")("docker build context2 -t reg2/repo2:tag2 ")
+      1 * getPipelineMock("sh")("docker build -f Dockerfile context1 -t reg1/repo1:tag1 ")
+      1 * getPipelineMock("sh")("docker build -f Dockerfile.test context2 -t reg2/repo2:tag2 ")
   }
 
   def "Each Image is Properly Pushed" () {

--- a/libraries/docker/test/GetImagesToBuildSpec.groovy
+++ b/libraries/docker/test/GetImagesToBuildSpec.groovy
@@ -37,7 +37,7 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
     when:
       def imageList = GetImagesToBuild()
     then:
-      imageList == [[registry: "test_registry", repo:repo , context: build_context, tag: "8675309"]]
+      imageList == [[registry: "test_registry", repo:repo , context: build_context, tag: "8675309", dockerfile: "Dockerfile"]]
     where:
       build_strategy | build_context | repo
       "dockerfile"   | "."           | "git_repo"
@@ -52,7 +52,7 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
     when:
       def imageList = GetImagesToBuild()
     then:
-      imageList == [[registry: "test_registry", repo: repo, context: build_context, tag: "8675309"]]
+      imageList == [[registry: "test_registry", repo: repo, context: build_context, tag: "8675309", dockerfile: "Dockerfile"]]
     where:
       build_strategy | build_context | repo
       "dockerfile"   | "."           | "test_prefix/git_repo"
@@ -67,7 +67,7 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
     when:
       def imageList = GetImagesToBuild()
     then:
-      imageList == [[registry: "test_registry", repo: repo, context: build_context, tag: "8675309"]]
+      imageList == [[registry: "test_registry", repo: repo, context: build_context, tag: "8675309", dockerfile: "Dockerfile"]]
     where:
       build_strategy | build_context | repo
       "dockerfile"   | "."           | "test_prefix/my-cool-image-name"
@@ -80,12 +80,13 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
     when:
       GetImagesToBuild()
     then:
-      y * getPipelineMock("error")("build strategy: ${x} not one of [docker-compose, modules, dockerfile, buildx]")
+      y * getPipelineMock("error")("build strategy: ${x} not one of [docker-compose, modules, dockerfiles, dockerfile, buildx]")
     where:
       x                | y
       "docker-compose" | 0
       "Kobayashi Maru" | 1
       "modules"        | 0
+      "dockerfiles"     | 0
       "dockerfile"     | 0
       "Starfleet"      | 1
       "buildx"         | 0
@@ -114,12 +115,14 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
           registry: "test_registry",
           repo: "vulcan_planet",
           context: "planet",
-          tag: "1234abcd"
+          tag: "1234abcd",
+          dockerfile: "Dockerfile"
         ], [
           registry: "test_registry",
           repo: "vulcan_planet2",
           context: "planet2",
-          tag: "1234abcd"
+          tag: "1234abcd",
+          dockerfile: "Dockerfile"
         ]
       ]
   }
@@ -132,7 +135,7 @@ public class GetImagesToBuildSpec extends JTEPipelineSpecification {
     when:
       def imageList = GetImagesToBuild()
     then:
-      imageList == [[registry: "test_registry", repo: "vulcan", context: ".", tag: "5678efgh"]]
+      imageList == [[registry: "test_registry", repo: "vulcan", context: ".", tag: "5678efgh", dockerfile: "Dockerfile"]]
   }
 
   def "buildx build_strategy Builds Correct Image for single multiarch image" () {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes -->

## Description

<!--- Describe your changes in detail -->

Added a new Docker build strategy called `dockerfiles` to support multiple Dockerfiles and/or Dockerfiles with custom file names (i.e. `Dockerfile.backend`, `Dockerfile.frontend`, etc.).

This supports the monorepo use-case where files needed to be shared between different Docker images.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a Jenkins pipeline using the following config:
```groovy
libraries {
  docker {
    registry = '<redacted>'
    cred = 'repo-creds'
    image_name = 'my-project'
    build_strategy = 'dockerfiles'
    dockerfiles {
      backend {
        context = '.'
        dockerfile = 'Dockerfile.backend'
      }
      frontend {
        context = '.'
        dockerfile = 'Dockerfile.frontend'
      }
    }
  }
}
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
