### PR TITLE
Add immutable option to yarn install

### DIFF
--- a/libraries/yarn/README.md
+++ b/libraries/yarn/README.md
@@ -39,8 +39,8 @@ libraries {
 | `yarn_version`                | Yarn version to use                                                                                                                    | `latest`          |
 | `<step name>.stageName`       | stage name displayed in the Jenkins dashboard                                                                                          | N/A               |
 | `<step name>.script`          | Yarn script ran by the step                                                                                                            | N/A               |
-| `<step name>.artifacts`       | array of glob patterns for artifacts that should be archived                                                                           |
-| `<step name>.yarnInstall`     | Yarn install command to run; Yarn install can be skipped with value "skip"                                                             | `frozen-lockfile` |
+| `<step name>.artifacts`       | array of glob patterns for artifacts that should be archived                                                                           |                   |
+| `<step name>.yarnInstall`     | Yarn install command to run; Yarn install can be skipped with value `skip`; Also supports `immutable` for Yarn 3 setups                | `frozen-lockfile` |
 | `<step name>.env`             | environment variables to make available to the Yarn process; can include key/value pairs and secrets                                   | `[]`              |
 | `<step name>.env.secrets`     | text or username/password credentials to make available to the Yarn process; must be present and available in Jenkins credential store | `[]`              |
 | `<step name>.useEslintPlugin` | if the Jenkins ESLint Plugin is installed, will run the `recordIssues` step to send lint results to the plugin dashboard               | `false`           |

--- a/libraries/yarn/steps/yarn_invoke.groovy
+++ b/libraries/yarn/steps/yarn_invoke.groovy
@@ -166,13 +166,15 @@ void setEnvVars(libStepConfig, appStepConfig, config, app_env) {
                          libStepConfig?.yarnInstall ?:
                          "frozen-lockfile"
 
-    if (!["install", "frozen-lockfile", "skip"].contains(yarnInstall)) {
-        error("yarnInstall must be one of \"install\", \"frozen-lockfile\" or \"skip\"; got \"$yarnInstall\"")
+    if (!["install", "frozen-lockfile", "skip", "immutable"].contains(yarnInstall)) {
+        error("yarnInstall must be one of \"install\", \"frozen-lockfile\" \"skip\" or \"immutable\"; got \"$yarnInstall\"")
     }
 
     env.yarnInstall = (yarnInstall == "frozen-lockfile")
                       ? "install --frozen-lockfile"
-                      : yarnInstall
+                      : (yarnInstall == "immutable")
+                        ? "install --immutable"
+                        : yarnInstall
 
     env.scriptCommand = appStepConfig?.script ?:
                         libStepConfig?.script ?:

--- a/libraries/yarn/test/YarnInvokeSpec.groovy
+++ b/libraries/yarn/test/YarnInvokeSpec.groovy
@@ -174,6 +174,16 @@ public class YarnInvokeSpec extends JTEPipelineSpecification {
       1 * getPipelineMock("sh")(shellCommandWithoutYarnInstall)
   }
 
+  def "Uses Yarn install with 'immutable' when yarnInstall is set to \"immutable\"; runs yarn install step" () {
+    setup:
+      YarnInvoke.getBinding().setVariable("config", [unit_test: [stageName: "Yarn Unit Tests", script: "test", yarnInstall: "immutable"]])
+    when:
+      YarnInvoke()
+    then:
+      YarnInvoke.getBinding().variables.env.yarnInstall == "install --immutable"
+      1 * getPipelineMock("sh")(shellCommandWithYarnInstall)
+  }
+
   def "Archives artifacts correctly" () {
     setup:
       YarnInvoke.getBinding().setVariable("config", [


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes -->
Adds an `immutable` option to the yarn library `yarnInstall` configuration field

## Description

<!--- Describe your changes in detail -->
This adds the `immutable` option to `yarnInstall` to support Yarn 3 users. `frozen-lockfile` was the way to do this in previous Yarn versions. This no longer exists in Yarn 3 and was replaced with the `immutable` flag.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
