### PR TITLE
Add separate git repo option to NPM library

### DIFF
--- a/libraries/npm/README.md
+++ b/libraries/npm/README.md
@@ -32,17 +32,23 @@ libraries {
 
 ---
 
-| Field                         | Description                                                                                                                           | Default   |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `nvm_container`               | The container image to use                                                                                                            | nvm:1.0.0 |
-| `node_version`                | Node version to run NPM within (installed via NVM)                                                                                    | `lts/*`   |
-| `<step name>.stageName`       | stage name displayed in the Jenkins dashboard                                                                                         | N/A       |
-| `<step name>.script`          | NPM script ran by the step                                                                                                            | N/A       |
-| `<step name>.artifacts`       | array of glob patterns for artifacts that should be archived                                                                          |
-| `<step name>.npmInstall`      | NPM install command to run; npm install can be skipped with value "skip"                                                              | `ci`      |
-| `<step name>.env`             | environment variables to make available to the NPM process; can include key/value pairs and secrets                                   | `[]`      |
-| `<step name>.env.secrets`     | text or username/password credentials to make available to the NPM process; must be present and available in Jenkins credential store | `[]`      |
-| `<step name>.useEslintPlugin` | if the Jenkins ESLint Plugin is installed, will run the `recordIssues` step to send lint results to the plugin dashboard              | `false`   |
+| Field                         | Description                                                                                                                           | Default     |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `nvm_container`               | The container image to use                                                                                                            | `nvm:1.0.0` |
+| `node_version`                | Node version to run NPM within (installed via NVM)                                                                                    | `lts/*`     |
+| `<step name>.stageName`       | stage name displayed in the Jenkins dashboard                                                                                         | N/A         |
+| `<step name>.script`          | NPM script ran by the step                                                                                                            | N/A         |
+| `<step name>.artifacts`       | array of glob patterns for artifacts that should be archived                                                                          | `[]`        |
+| `<step name>.npmInstall`      | NPM install command to run; npm install can be skipped with value "skip"                                                              | `ci`        |
+| `<step name>.env`             | environment variables to make available to the NPM process; can include key/value pairs and secrets                                   | `[]`        |
+| `<step name>.env.secrets`     | text or username/password credentials to make available to the NPM process; must be present and available in Jenkins credential store | `[]`        |
+| `<step name>.useEslintPlugin` | if the Jenkins ESLint Plugin is installed, will run the `recordIssues` step to send lint results to the plugin dashboard              | `false`     |
+| `<step name>.nvm_container`   | The container image to use (if overriding library default)                                                                            | N/A         |
+| `<step name>.node_version`    | Node version to run NPM within (if overriding library default)                                                                        | N/A         |
+| `<step name>.git.url`         | Git repository to pull and run NPM script from (when different than base job/repository)                                              | N/A         |
+| `<step name>.git.cred`        | ID of credentials to pull the optional Git repository; must be present and available in Jenkins credential store                      | N/A         |
+| `<step name>.git.branch`      | Branch to checkout from optional Git repository                                                                                       | N/A         |
+
 
 ### Full Configuration Example
 
@@ -195,6 +201,17 @@ libraries {
             id = "some-credential-id"
           }
         }
+      }
+    }
+    end_to_end_tests {
+      stageName = "Cypress End-to-End Tests"
+      script = "cy:run"
+      artifacts = ["cypress-results/**/*"]
+      nvm_container = "nvm-chrome-1.0.0"
+      git {
+        url = "https://www.github.com/myaccount/mycypresstestrepo"
+        cred = "github-pat"
+        branch = "main"
       }
     }
   }

--- a/libraries/npm/README.md
+++ b/libraries/npm/README.md
@@ -38,6 +38,7 @@ libraries {
 | `node_version`                | Node version to run NPM within (installed via NVM)                                                                                    | `lts/*`     |
 | `<step name>.stageName`       | stage name displayed in the Jenkins dashboard                                                                                         | N/A         |
 | `<step name>.script`          | NPM script ran by the step                                                                                                            | N/A         |
+| `<step name>.scriptArgs`      | array of arguments to pass to the NPM script                                                                                          | `[]`        |
 | `<step name>.artifacts`       | array of glob patterns for artifacts that should be archived                                                                          | `[]`        |
 | `<step name>.npmInstall`      | NPM install command to run; npm install can be skipped with value "skip"                                                              | `ci`        |
 | `<step name>.env`             | environment variables to make available to the NPM process; can include key/value pairs and secrets                                   | `[]`        |
@@ -141,6 +142,7 @@ libraries {
     unit_test {
       stageName = "NPM Unit Tests"
       script = "test"
+      scriptArgs = ["--test=my_tests/unit_test"]
       npmInstall = "install"
       env {
         someKey = "someValue for tests"
@@ -206,6 +208,7 @@ libraries {
     end_to_end_tests {
       stageName = "Cypress End-to-End Tests"
       script = "cy:run"
+      scriptArgs = ["--env=test", "--test=test_suites/my_tests/validation_test"]
       artifacts = ["cypress-results/**/*"]
       nvm_container = "nvm-chrome-1.0.0"
       git {

--- a/libraries/npm/steps/npm_invoke.groovy
+++ b/libraries/npm/steps/npm_invoke.groovy
@@ -11,7 +11,9 @@ void call(app_env = [:]) {
     LinkedHashMap libStepConfig = config?."${stepContext.name}" ?: [:]
     LinkedHashMap appStepConfig = app_env?.npm?."${stepContext.name}" ?: [:]
 
-    String nvmContainer = config?.nvm_container ?: "nvm:1.0.0"
+    String nvmContainer = libStepConfig?.nvm_container ?:
+                          config?.nvm_container ?:
+                          "nvm:1.0.0"
 
     String stageName = appStepConfig?.stageName ?:
                        libStepConfig?.stageName ?:
@@ -33,62 +35,78 @@ void call(app_env = [:]) {
         this.setEnvVars(libStepConfig, appStepConfig, config, app_env)
 
         // run npm command in nvm container
-        withCredentials(creds) {
-            inside_sdp_image(nvmContainer) {
-                unstash "workspace"
+        def npmBlock = {
+            withCredentials(creds) {
+                inside_sdp_image(nvmContainer) {
+                    unstash "workspace"
 
-                // verify package.json script block has command to run
-                def packageJson = readJSON(file: "package.json")
-                if (!packageJson?.scripts?.containsKey(env.scriptCommand)) {
-                    error("script: '$env.scriptCommand' not found in package.json scripts")
-                }
-                
-                try {
-                    if (env.npmInstall != "skip") {
-                        // run script command after installing dependencies
-                        sh '''
-                            set +x
-                            source ~/.bashrc
-                            nvm install $node_version
-                            nvm version
-
-                            echo 'Running with NPM install'
-                            npm $npmInstall
-                            npm run $scriptCommand
-                        '''
-                    }
-                    else {
-                        // run script command without installing dependencies
-                        sh '''
-                            set +x
-                            source ~/.bashrc
-                            nvm install $node_version
-                            nvm version
-
-                            echo 'Running without NPM install'
-                            npm run $scriptCommand
-                        '''
-                    }
-                }
-                catch (any) {
-                    throw any
-                }
-                finally {
-                    // archive artifacts
-                    artifacts.each{ artifact ->
-                        archiveArtifacts artifacts: artifact, allowEmptyArchive: true
+                    // verify package.json script block has command to run
+                    def packageJson = readJSON(file: "package.json")
+                    if (!packageJson?.scripts?.containsKey(env.scriptCommand)) {
+                        error("script: '$env.scriptCommand' not found in package.json scripts")
                     }
 
-                    // check if using ESLint plugin
-                    def usingEslintPlugin = appStepConfig?.useEslintPlugin ?:
-                                            libStepConfig?.useEslintPlugin ?:
-                                            false
+                    try {
+                        if (env.npmInstall != "skip") {
+                            // run script command after installing dependencies
+                            sh '''
+                                set +x
+                                source ~/.bashrc
+                                nvm install $node_version
+                                nvm version
 
-                    if (usingEslintPlugin) {
-                        recordIssues enabledForFailure: true, tool: esLint(pattern: 'eslint-report.xml')
+                                echo 'Running with NPM install'
+                                npm $npmInstall
+                                npm run $scriptCommand
+                            '''
+                        }
+                        else {
+                            // run script command without installing dependencies
+                            sh '''
+                                set +x
+                                source ~/.bashrc
+                                nvm install $node_version
+                                nvm version
+
+                                echo 'Running without NPM install'
+                                npm run $scriptCommand
+                            '''
+                        }
+                    }
+                    catch (any) {
+                        throw any
+                    }
+                    finally {
+                        // archive artifacts
+                        artifacts.each{ artifact ->
+                            archiveArtifacts artifacts: artifact, allowEmptyArchive: true
+                        }
+
+                        // check if using ESLint plugin
+                        def usingEslintPlugin = appStepConfig?.useEslintPlugin ?:
+                                                libStepConfig?.useEslintPlugin ?:
+                                                false
+
+                        if (usingEslintPlugin) {
+                            recordIssues enabledForFailure: true, tool: esLint(pattern: 'eslint-report.xml')
+                        }
                     }
                 }
             }
+        }
+
+        if (libStepConfig.git) {
+            try {
+                withGit url: libStepConfig.git.url, cred: libStepConfig.git.cred, branch: libStepConfig.git.branch, {
+                    npmBlock()
+                }
+            }
+            catch (any) {
+                throw any
+            }
+        }
+        else {
+            npmBlock()
         }
     }
 }
@@ -150,7 +168,9 @@ void setEnvVars(libStepConfig, appStepConfig, config, app_env) {
         env[it.key] = it.value
     }
 
-    env.node_version = app_env?.npm?.node_version ?: 
+    env.node_version = appStepConfig?.node_version ?:
+                       libStepConfig?.node_version ?:
+                       app_env?.npm?.node_version ?:
                        config?.node_version ?:
                        'lts/*'
     

--- a/libraries/npm/steps/npm_invoke.groovy
+++ b/libraries/npm/steps/npm_invoke.groovy
@@ -57,7 +57,7 @@ void call(app_env = [:]) {
 
                                 echo 'Running with NPM install'
                                 npm $npmInstall
-                                npm run $scriptCommand
+                                npm run $scriptCommand $scriptArgs
                             '''
                         }
                         else {
@@ -69,7 +69,7 @@ void call(app_env = [:]) {
                                 nvm version
 
                                 echo 'Running without NPM install'
-                                npm run $scriptCommand
+                                npm run $scriptCommand $scriptArgs
                             '''
                         }
                     }
@@ -185,6 +185,11 @@ void setEnvVars(libStepConfig, appStepConfig, config, app_env) {
     env.scriptCommand = appStepConfig?.script ?:
                         libStepConfig?.script ?:
                         null
+
+    def scriptArgs = appStepConfig?.scriptArgs ?:
+                     libStepConfig?.scriptArgs ?:
+                     []
+    env.scriptArgs = scriptArgs.join(" ")
 
     if (!env.scriptCommand) {
         error("No script command found for step: " + stepContext.name)

--- a/libraries/npm/steps/npm_invoke.groovy
+++ b/libraries/npm/steps/npm_invoke.groovy
@@ -38,6 +38,7 @@ void call(app_env = [:]) {
         def npmBlock = {
             withCredentials(creds) {
                 inside_sdp_image(nvmContainer) {
+                    // if we're running inside a different Git repo, don't unstash
                     if (!libStepConfig.git) {
                         unstash "workspace"
                     }

--- a/libraries/npm/steps/npm_invoke.groovy
+++ b/libraries/npm/steps/npm_invoke.groovy
@@ -35,6 +35,7 @@ void call(app_env = [:]) {
         this.setEnvVars(libStepConfig, appStepConfig, config, app_env)
 
         // run npm command in nvm container
+        @NonCPS
         def npmBlock = {
             withCredentials(creds) {
                 inside_sdp_image(nvmContainer) {

--- a/libraries/npm/steps/npm_invoke.groovy
+++ b/libraries/npm/steps/npm_invoke.groovy
@@ -35,11 +35,12 @@ void call(app_env = [:]) {
         this.setEnvVars(libStepConfig, appStepConfig, config, app_env)
 
         // run npm command in nvm container
-        @NonCPS
         def npmBlock = {
             withCredentials(creds) {
                 inside_sdp_image(nvmContainer) {
-                    unstash "workspace"
+                    if (!libStepConfig.git) {
+                        unstash "workspace"
+                    }
 
                     // verify package.json script block has command to run
                     def packageJson = readJSON(file: "package.json")

--- a/libraries/npm/test/NpmInvokeSpec.groovy
+++ b/libraries/npm/test/NpmInvokeSpec.groovy
@@ -9,25 +9,25 @@ public class NpmInvokeSpec extends JTEPipelineSpecification {
   def NpmInvoke = null
 
   def shellCommandWithNpmInstall = '''
-                            set +x
-                            source ~/.bashrc
-                            nvm install $node_version
-                            nvm version
+                                set +x
+                                source ~/.bashrc
+                                nvm install $node_version
+                                nvm version
 
-                            echo 'Running with NPM install'
-                            npm $npmInstall
-                            npm run $scriptCommand
-                        '''
+                                echo 'Running with NPM install'
+                                npm $npmInstall
+                                npm run $scriptCommand
+                            '''
 
   def shellCommandWithoutNpmInstall = '''
-                            set +x
-                            source ~/.bashrc
-                            nvm install $node_version
-                            nvm version
+                                set +x
+                                source ~/.bashrc
+                                nvm install $node_version
+                                nvm version
 
-                            echo 'Running without NPM install'
-                            npm run $scriptCommand
-                        '''
+                                echo 'Running without NPM install'
+                                npm run $scriptCommand
+                            '''
 
   LinkedHashMap minimalUnitTestConfig = [
     unit_test: [

--- a/libraries/npm/test/NpmInvokeSpec.groovy
+++ b/libraries/npm/test/NpmInvokeSpec.groovy
@@ -16,7 +16,7 @@ public class NpmInvokeSpec extends JTEPipelineSpecification {
 
                                 echo 'Running with NPM install'
                                 npm $npmInstall
-                                npm run $scriptCommand
+                                npm run $scriptCommand $scriptArgs
                             '''
 
   def shellCommandWithoutNpmInstall = '''
@@ -26,7 +26,7 @@ public class NpmInvokeSpec extends JTEPipelineSpecification {
                                 nvm version
 
                                 echo 'Running without NPM install'
-                                npm run $scriptCommand
+                                npm run $scriptCommand $scriptArgs
                             '''
 
   LinkedHashMap minimalUnitTestConfig = [


### PR DESCRIPTION
# PR Details

## Description

Adds the option to define a `git{}` config under a custom step defined in the NPM library. The `git` block requires three parameters that set the repo (`url`), branch (`branch`), and Jenkins stored credential ID (`cred`) to pull a repository down and run the NPM script defined within that context. Useful, for example, if end-to-end test code is stored in a separate repository from your main codebase.

## How Has This Been Tested

Locally, and with additional unit tests

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
