### PR TITLE
fix: add optional flag that allows skipping npm audit checks with OWASP dependency-check scanner

### DIFF
--- a/libraries/owasp_dep_check/README.md
+++ b/libraries/owasp_dep_check/README.md
@@ -31,7 +31,7 @@ OWASP Dependency Check Library Configuration Options
 | `allow_suppression_file` | Allows whitelisting vulnerabilities using a suppression XML file                                                                                        | `true`                             |
 | `suppression_file`       | Path to the suppression file (see [here](https://jeremylong.github.io/DependencyCheck/general/suppression.html) for how to create a suppression file)   | `dependency-check-suppression.xml` |
 | `image_tag`              | The tag for the scanner Docker image used                                                                                                               | `7.3.0-8.6-2`                      |
-| `skip_node_audit`        | SKips the node audit with `--disableNodeAudit` if set to true. This can be useful if you have other mechanisms to audit npm packages (ex: npm audit).   |                                    |
+| `skip_node_audit`        | Skips the node audit with `--disableNodeAudit` if set to true. This can be useful if you have other mechanisms to audit npm packages (ex: npm audit).   |                                    |
 
 ## Example Configuration Snippet
 

--- a/libraries/owasp_dep_check/README.md
+++ b/libraries/owasp_dep_check/README.md
@@ -31,6 +31,7 @@ OWASP Dependency Check Library Configuration Options
 | `allow_suppression_file` | Allows whitelisting vulnerabilities using a suppression XML file                                                                                        | `true`                             |
 | `suppression_file`       | Path to the suppression file (see [here](https://jeremylong.github.io/DependencyCheck/general/suppression.html) for how to create a suppression file)   | `dependency-check-suppression.xml` |
 | `image_tag`              | The tag for the scanner Docker image used                                                                                                               | `7.3.0-8.6-2`                      |
+| `skip_node_audit`        | SKips the node audit with `--disableNodeAudit` if set to true. This can be useful if you have other mechanisms to audit npm packages (ex: npm audit).   |                                    |
 
 ## Example Configuration Snippet
 

--- a/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
+++ b/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
@@ -43,7 +43,7 @@ void call() {
         }
       }
       
-      Boolean skipNodeAudit = config?.skip_node_audit ?: true
+      Boolean skipNodeAudit = config?.skip_node_audit ?: false
       if (skipNodeAudit) {
         args += " --disableNodeAudit"
       } 

--- a/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
+++ b/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
@@ -42,6 +42,11 @@ void call() {
           echo "\"${suppressionFile}\" does not exist. Skipping suppression."
         }
       }
+      
+      Boolean skipNodeAudit = config?.skip_node_audit ?: true
+      if (skipNodeAudit) {
+        args += "--disableNodeAudit"
+      } 
 
       // perform the scan
       try {

--- a/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
+++ b/libraries/owasp_dep_check/steps/application_dependency_scan.groovy
@@ -45,7 +45,7 @@ void call() {
       
       Boolean skipNodeAudit = config?.skip_node_audit ?: true
       if (skipNodeAudit) {
-        args += "--disableNodeAudit"
+        args += " --disableNodeAudit"
       } 
 
       // perform the scan


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes -->

Allow users to skip npm auditing via flag.

## Description

<!--- Describe your changes in detail -->

This allows skipping npm audit checks. The core error returned for us (needing us to add this flag to optionally skip this test):

```
Could not perform Node Audit analysis. Invalid payload submitted to Node Audit API.
```

This can be tested independently. This is mainly because tests can fail because of possible bugs upstream with the OWASP dependency checker itself (it appears to be brittle/flaky/unknown in why it tends to error):

https://github.com/search?q=repo%3Ajeremylong%2FDependencyCheck+Could+not+perform+Node+Audit+analysis.+Invalid+payload+submitted+to+Node+Audit+API&type=issues

They vary from duplicated dependencies (which npm may allow, but the npm audit may not, which owasp does not honor by avoiding deduplication) to simply unknown/major version releases.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This was tested manually in a jenkins setup with @ltdonner-bah's review. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I am submitting this pull request to the appropriate branch
- [x] I have labeled this pull request appropriately
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
