### PR TITLE
Support withMaven step

### DIFF
--- a/libraries/maven/README.md
+++ b/libraries/maven/README.md
@@ -43,6 +43,17 @@ libraries {
       phases = ['build']
       artifacts = ['target/*.jar']
     }
+    aThirdMavenStep {
+      stageName = 'Maven Build'
+      buildContainer = 'mvn'
+      phases = ['build']
+      artifacts = ['target/*.jar']
+      withMavenParams = [
+        'globalMavenSettingsConfig': '1c11594b-8b27-4f9e-a83c-3f2e72969514',
+        'mavenOpts': '-Dsettings.security=/var/lib/jenkins/settings-security.xml',
+        'traceability': false
+      ]
+    }
   }
 }
 ```

--- a/libraries/maven/steps/maven_invoke.groovy
+++ b/libraries/maven/steps/maven_invoke.groovy
@@ -28,6 +28,10 @@ void call(app_env = [:]) {
                     libStepConfig?.artifacts ?:
                     [] as String[]
 
+    def withMavenParams = appStepConfig?.withMavenParams ?:
+                    libStepConfig?.withMavenParams ?:
+                    [] as String[]
+
     // Gather and set non-secret environment variables
     this.setEnvVars(libStepConfig, appStepConfig)
 
@@ -40,13 +44,19 @@ void call(app_env = [:]) {
             inside_sdp_image "${env.buildContainer}", {
                 unstash 'workspace'
 
-                String command = 'mvn '
+                String command = withMavenParams ? '$MVN_CMD ' : 'mvn '
                 options.each { value -> command += "${value} " }
                 goals.each { value -> command += "${value} " }
                 phases.each { value -> command += "${value} " }
 
                 try {
-                    sh command
+                    if (withMavenParams) {
+                      withMaven (withMavenParams) {
+                          sh command
+                      }
+                    } else {
+                      sh command
+                    }
                 }
                 catch (any) {
                     throw any


### PR DESCRIPTION
# PR Details

We use the pretty useful [Pipeline Maven Integration plugin](https://plugins.jenkins.io/pipeline-maven/) to run Maven jobs. One of its features is that when you wrap your Maven execution with `withMaven`, which the plugin provides, it spies on the generated artifacts and then stores their GAV in a DB. Thanks to that information it's then able to trigger downstream SNAPSHOT projects on the same instance automatically. This is vital in our setup but we also very much enjoy what the SDP Maven library offers out of the box, so we thought to add support for the plugin right here.

## Description

The PR adds an optional `withMavenParams` field to the step configuration. As soon as the map contains a property, and only if the map contains anything, the Maven invocation is then wrapped with the `withMaven` step (which requires the plugin to be installed).

## How Has This Been Tested

I have configured a local Jenkins instance to use my fork of the libraries and confirmed that defining this parameter wraps the Maven execution with `withMaven`, whereas not defining it leaves the build unchanged.

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I am submitting this pull request to the appropriate branch
- [X] I have labeled this pull request appropriately
- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
